### PR TITLE
Create a class CellSet to provide a unified interface for managing cell sets

### DIFF
--- a/TODO
+++ b/TODO
@@ -19,7 +19,3 @@
 
 - maplib
   - move game-state.mjs out
-  - create map-utils.mjs
-    - class MapCoord
-    - class CellSet
-    - utility function: tells if a MapCoord is inside a CellSet

--- a/common/extlib/extension-helper-base.mjs
+++ b/common/extlib/extension-helper-base.mjs
@@ -150,10 +150,12 @@ class ExtensionHelperBase {
 
   /**
    * Broadcast a cell set update to all clients.
-   * @param {object} cset - The cell set. See GameState.onCellSet for doc.
+   * @param {String} op - The operation type: "set", "unset", or "update"
+   * @param {String} mapName - The map which this cell set applies to.
+   * @param {CellSet} cellSet - The cell set object.
    */
-  async broadcastCellSetUpdateToAllUser(cset) {
-    await this.broadcaster.notifyPlayerCellSetChange(cset);
+  async broadcastCellSetUpdateToAllUser(op, mapName, cellSet) {
+    await this.broadcaster.notifyPlayerCellSetChange(op, mapName, cellSet);
   }
 }
 

--- a/common/maplib/cellset.mjs
+++ b/common/maplib/cellset.mjs
@@ -1,0 +1,87 @@
+// Copyright 2021 HITCON Online Contributors
+// SPDX-License-Identifier: BSD-2-Clause
+
+/**
+ * This file defines the interface of a cell set.
+ * An example format of a CellSet can be found at the end of the file.
+ */
+
+/**
+ * A cell set is a set of map coordinates that have some special meaning.
+ * Note that a cell set is applied to `_SingleMap` instead of `GameMap`, and
+ * therefore a cell set does not have `mapName` property.
+ *
+ * The greater value of property `priority`, the higher priority the cell set is.
+ * If two cell set has the same priority, prefer dynamic cell set over static one.
+ */
+class CellSet {
+  /**
+   * @constructor
+   * @param {String} name - the name of the cell set
+   * @param {Number} priority - an integer; greater value means higher priority
+   * @param {Array} cells - a list of object {x, y, w, h}
+   * @param {Object} layers - the layers to overwrite
+   * @param {Boolean} dynamic - (optional) whether this cell set is dynamic cell set;
+   * default to `true`
+   */
+  constructor(name, priority, cells, layers, dynamic) {
+    this.name = name;
+    this.priority = priority;
+    this.cells = (cells ?? []);
+    this.layers = (layers ?? {});
+    this.dynamic = (dynamic ?? true);
+  }
+
+  /**
+   * Check if mapCoord lies inside this cell set.
+   * Does not care the mapName of mapCoord.
+   * @param {MapCoord} mapCoord - The map coordinate. `mapName` is ignored.
+   * @return {Boolean}
+   */
+  containsMapCoord(mapCoord) {
+    return mapCoord.insideCellSet(this);
+  }
+
+  /**
+   * The serialization used by JSON.stringify().
+   * @return {Object}
+   */
+  toJSON() {
+    return {
+      name: this.name,
+      priority: this.priority,
+      cells: this.cells,
+      layers: this.layers,
+      dynamic: this.dynamic,
+    };
+  }
+
+  /**
+   * Deserialize a JSON object into CellSet.
+   * @param {Object} obj - the JSON object
+   * @return {CellSet}
+   */
+  static fromObject(obj) {
+    return new CellSet(obj.name, obj.priority, obj.cells, obj.layers, obj.dynamic);
+  }
+}
+
+export default CellSet;
+
+/**
+ * An example format of a CellSet:
+ *
+ * {
+ *   "name": "bombmanObstacles1",
+ *   "priority": 2,
+ *   "cells": [
+ *     { "x": 3, "y": 5, "w": 2, "h": 1 },
+ *     { "x": 6, "y": 3, "w": 1, "h": 1 }
+ *   ],
+ *   "layers": {
+ *     "bombmanObstacle": "O",
+ *     "wall": true
+ *   },
+ *   "dynamic": false
+ * }
+ */

--- a/extensions/cellsettest/client.mjs
+++ b/extensions/cellsettest/client.mjs
@@ -16,33 +16,14 @@ class Client {
     this.helper = helper;
     document.getElementById('ccs').addEventListener('click', () => {this.requestChangeCellset(this);});
     console.log("cellset extension loaded");
-    this.socket = io();
+
+    window.testCellSet = this.requestChangeCellset.bind(this);
   }
 
-  /**
-   * Returns true if this extension have a browser side part.
-   * If this returns false, the constructor for Client will not be called.
-   * @return {Boolean} haveClient - See above.
-   */
-  static haveClient() {
-    return false;
+  requestChangeCellset() {
+    console.log('requestChangeCellset');
+    this.helper.callC2sAPI('cellsettest', 'changeCellSet', null, 5000);
   }
-
-  onExtensionBroadcast(msg) {
-    console.log(msg);
-  }
-
-  requestChangeCellset(client) {
-    console.log("requestChangeCellset", client)
-    client.helper.callStandaloneAPI('changeCellSet', null, 5000);
-  }
-
-  /**
-   * The below static variable is used to configure the api functions that you want to expose to the client
-   */
-  static apis = {
-    "SayHello": "clientHello",
-  };
 }
 
 export default Client;

--- a/extensions/cellsettest/standalone.mjs
+++ b/extensions/cellsettest/standalone.mjs
@@ -1,8 +1,7 @@
 // Copyright 2021 HITCON Online Contributors
 // SPDX-License-Identifier: BSD-2-Clause
 
-import assert from 'assert';
-
+import CellSet from '../../common/maplib/cellset.mjs';
 
 /**
  * This represents the standalone extension service for this extension.
@@ -16,7 +15,7 @@ class Standalone {
    */
   constructor(helper) {
     this.helper = helper;
-    this.set = false;
+    this.state = 0;
   }
 
   /**
@@ -35,28 +34,52 @@ class Standalone {
     return false;
   }
 
-  changeCellSet() {
-    if (!this.set) {
-      this.helper.broadcastCellSetUpdateToAllUser({
-        type: 'set',
-        cellSet: {
-          'name': 'testDynamic',
-          'priority': 4,
-          'cells': [
-            {'x': 1, 'y': 1, 'h': 18, 'w': 18},
-          ],
-          'layers': [
-            {'ground': 'P'},
-          ],
-        },
-      });
-    } else {
-      this.helper.broadcastCellSetUpdateToAllUser({
-        type: 'unset',
-        name: 'testDynamic',
-      });
+  c2s_changeCellSet() {
+    switch (this.state) {
+      case 0:
+        this.helper.broadcastCellSetUpdateToAllUser(
+            'set', // operation type
+            'world1',
+            CellSet.fromObject({
+              name: 'testDynamic',
+              priority: 4,
+              cells: [{'x': 10, 'y': 10, 'h': 8, 'w': 8}],
+              layers: {ground: 'P'},
+              dynamic: true,
+            }),
+        );
+        this.state = 1;
+        break;
+
+      case 1:
+        this.helper.broadcastCellSetUpdateToAllUser(
+            'update', // operation type
+            'world1',
+            CellSet.fromObject({
+              name: 'testDynamic',
+              cells: [
+                {'x': 10, 'y': 10, 'h': 8, 'w': 8},
+                {'x': 12, 'y': 5, 'h': 4, 'w': 4},
+              ],
+            }),
+        );
+        this.state = 2;
+        break;
+
+      case 2:
+        this.helper.broadcastCellSetUpdateToAllUser(
+            'unset', // operation type
+            'world1',
+            CellSet.fromObject({
+              name: 'testDynamic',
+            }),
+        );
+        this.state = 0;
+        break;
+
+      default:
+        console.error(`invalid \`this.state\`, value = ${this.state}`);
     }
-    this.set = !this.set;
   }
 
   /**

--- a/run/map/map.json
+++ b/run/map/map.json
@@ -92,17 +92,17 @@
     "startY": 0,
     "width": 20,
     "height": 20,
-    "cellSet": [
+    "cellSets": [
       {
         "name": "bombmanArena1",
         "priority": 1,
         "cells": [
           { "x": 2, "y": 2, "w": 6, "h": 6 }
         ],
-        "layers": [
-          { "ground": "H" },
-          { "wall": false }
-        ]
+        "layers": {
+          "ground": "H",
+          "wall": false
+        }
       },
       {
         "name": "bombmanObstacles1",
@@ -111,10 +111,10 @@
           { "x": 3, "y": 5, "w": 2, "h": 1 },
           { "x": 6, "y": 3, "w": 1, "h": 1 }
         ],
-        "layers": [
-          { "bombmanObstacle": "O" },
-          { "wall": true }
-        ]
+        "layers": {
+          "bombmanObstacle": "O",
+          "wall": true
+        }
       }
     ]
   }

--- a/services/gateway/all-area-broadcaster.mjs
+++ b/services/gateway/all-area-broadcaster.mjs
@@ -43,7 +43,7 @@ class AllAreaBroadcaster {
           this.onLocation(obj.msg);
         } else if (obj.type == 'extBC') {
           this.onExtensionBroadcast(obj.msg);
-        } else if (obj.type == 'cset') {
+        } else if (obj.type == 'cellSet') {
           this.onCellSetBroadcast(obj.msg);
         }
       }
@@ -64,11 +64,13 @@ class AllAreaBroadcaster {
 
   /**
    * Call this to notify player cell set change. This will send data to redis.
-   * @param {object} cset - The cell set object, see GameState.onCellSet for doc.
+   * @param {String} op - The operation type: "set", "unset", or "update"
+   * @param {String} mapName - The map which this cell set applies to.
+   * @param {CellSet} cellSet - The cell set object.
    */
-  async notifyPlayerCellSetChange(cset) {
-    this.gameState.onCellSet(cset);
-    let msg = {type: 'cset', msg: cset};
+  async notifyPlayerCellSetChange(op, mapName, cellSet) {
+    this.gameState.onCellSet(op, mapName, cellSet);
+    const msg = {type: 'cellSet', msg: {op, mapName, cellSet}};
     await this.dir.getRedis().publishAsync(this.gameStateChannel,
         JSON.stringify(msg));
   }

--- a/services/gateway/gateway-service.mjs
+++ b/services/gateway/gateway-service.mjs
@@ -68,9 +68,9 @@ class GatewayService {
       // Broadcast the extension broadcast.
       this.io.emit('extBC', bc);
     });
-    this.broadcaster.registerOnCellSetBroadcast((cset) => {
+    this.broadcaster.registerOnCellSetBroadcast((msg) => {
       // Broadcast the cell set modification.
-      this.io.emit('cset', cset);
+      this.io.emit('cellSet', msg);
     });
   }
 

--- a/sites/game-client/game-client.mjs
+++ b/sites/game-client/game-client.mjs
@@ -71,8 +71,8 @@ class GameClient {
         // Note: The method below is async but we ignore its promise.
         this.extMan.onExtensionBroadcast(msg);
       });
-      socket.on('cset', (cset) => {
-        this.gameState.onCellSet(cset);
+      socket.on('cellSet', (msg) => {
+        this.gameState.onCellSet(msg.op, msg.mapName, msg.cellSet);
       });
       socket.on('callS2cAPI', (msg, callback) => {
         let p = this.extMan.onS2cAPICalled(msg);


### PR DESCRIPTION
In this PR, I refactor the code related to cell sets.
* Create a class `CellSet` to provide a unified interface for cell sets
* Fix `cellsettest` extension so that it provides a correct example of using dynamic cell sets

I think this PR may affect some teammates' work. If so, maybe we can merge this PR before the next meeting.