### PR TITLE
Allow extensions to listen to player location changes and cell set changes

### DIFF
--- a/common/extlib/extension-helper-base.mjs
+++ b/common/extlib/extension-helper-base.mjs
@@ -16,6 +16,7 @@ class ExtensionHelperBase {
    * @constructor
    * @param {ExtensionManager} extMan - The extension manager.
    * @param {Directory} dir - An RPC Directory instance.
+   * @param {Handler} rpcHandler - An RPC Handler instance.
    * @param {AllAreaBroadcaster} broadcaster - A broadcaster for broadcasting
    * message.
    * @param {string} name - The name of the extension.
@@ -54,6 +55,25 @@ class ExtensionHelperBase {
     void [x, y, callback];
     assert.fail('Not supported, registerInteraction is only supported ' +
         'in derived class.');
+  }
+
+  /**
+   * Register an onLocation. If any player move, the callback will be called.
+   * @param {function} callback - The callback when any player moved,
+   * take a location object, see Gateway Service for doc.
+   */
+  registerOnLocation(callback) {
+    this.broadcaster.registerOnLocation(callback);
+  }
+
+  /**
+   * Register an onCellSetBroadcast. If any cellset is added/modified/removed,
+   * the callback will be called.
+   * @param {function} callback - The callback when cellset is changed, take a
+   * cell set object, see .
+   */
+  registerOnCellSetBroadcast(callback) {
+    this.broadcaster.registerOnCellSetBroadcast(callback);
   }
 
   /**
@@ -101,7 +121,8 @@ class ExtensionHelperBase {
    */
   async callS2cAPI(playerID, extensionName, methodName, timeout, ...args) {
     const playerService = await this.dir.getPlayerGatewayService(playerID);
-    const result = await this.rpcHandler.callRPC(playerService, 'callS2c', playerID, extensionName, methodName, timeout, args);
+    const result = await this.rpcHandler.callRPC(playerService, 'callS2c',
+        playerID, extensionName, methodName, timeout, args);
     return result;
   }
 
@@ -113,7 +134,8 @@ class ExtensionHelperBase {
    */
   async teleport(playerID, mapCoord, ...args) {
     const playerService = await this.dir.getPlayerGatewayService(playerID);
-    const result = await this.rpcHandler.callRPC(playerService, 'teleport', playerID, mapCoord, 'D');
+    const result = await this.rpcHandler.callRPC(playerService, 'teleport',
+        playerID, mapCoord, 'D');
     return result;
   }
 
@@ -135,7 +157,8 @@ class ExtensionHelperBase {
       console.error(`Service '${extName}' unavailable, got '${extService}'`);
       return {'error': 'Service unavailable'};
     }
-    const result = await this.rpcHandler.callRPC(extService, 'callS2s', this.name, methodName, args);
+    const result = await this.rpcHandler.callRPC(extService, 'callS2s',
+        this.name, methodName, args);
     return result;
   }
 

--- a/extensions/cellsettest/in-gateway.mjs
+++ b/extensions/cellsettest/in-gateway.mjs
@@ -1,8 +1,6 @@
 // Copyright 2021 HITCON Online Contributors
 // SPDX-License-Identifier: BSD-2-Clause
 
-import assert from 'assert';
-
 /**
  * This represents the in-gateway/in-area part of the extension.
  * One instance of InGateway will be created for each gateway service
@@ -16,7 +14,7 @@ class InGateway {
    * various functionalities of the extension.
    */
   constructor(helper) {
-    void helper;
+    this.helper = helper;
   }
 
   /**
@@ -24,6 +22,12 @@ class InGateway {
    * the extension.
    */
   async initialize() {
+    this.helper.registerOnLocation((loc) => {
+      console.log('in-gateway extension received: ', loc);
+    });
+    this.helper.registerOnCellSetBroadcast((cset) => {
+      console.log('in-gateway extension received: ', cset);
+    });
   }
 
   /**

--- a/extensions/cellsettest/standalone.mjs
+++ b/extensions/cellsettest/standalone.mjs
@@ -22,6 +22,12 @@ class Standalone {
    * Initializes the extension.
    */
   async initialize() {
+    this.helper.registerOnLocation((loc) => {
+      console.log('standalone extension received: ', loc);
+    });
+    this.helper.registerOnCellSetBroadcast((cset) => {
+      console.log('standalone extension received: ', cset);
+    });
   }
 
   /**

--- a/services/assets/asset-server-launcher.mjs
+++ b/services/assets/asset-server-launcher.mjs
@@ -6,14 +6,8 @@ import {createRequire} from 'module';
 const require = createRequire(import.meta.url);
 
 const express = require('express');
-const path = require('path');
 const config = require('config');
-const redis = require('redis');
-const {Server} = require('socket.io');
 const http = require('http');
-const argv = require('minimist')(process.argv.slice(2));
-
-import fs from 'fs';
 
 import AssetServer from './asset-server.mjs';
 import ExtensionManager from '../../common/extlib/extension-manager.mjs';
@@ -32,7 +26,9 @@ async function mainServer() {
 
   /* Create services */
   const extensionManager = new ExtensionManager(null, null, null, null);
-  const gatewayAddresses = [config.get('publicAddress')] ?? Object.values(config.get('gatewayServers')).map(v => v.httpAddress);
+  const gatewayAddresses = config.get('publicAddress') ?
+                          [config.get('publicAddress')] :
+                          Object.values(config.get('gatewayServers')).map((v) => v.httpAddress);
   const assetServer = new AssetServer(app, extensionManager, gatewayAddresses);
 
   /* Initialize static asset server */

--- a/services/gateway/all-area-broadcaster.mjs
+++ b/services/gateway/all-area-broadcaster.mjs
@@ -23,9 +23,10 @@ class AllAreaBroadcaster {
     this.gameMap = gameMap;
     this.gameStateChannel = AllAreaBroadcaster.gameStateChannel;
     this.gameState = gameState;
-    this.onLocation = () => {};
-    this.onExtensionBroadcast = () => {};
-    this.onCellSetBroadcast = () => {};
+
+    this.onLocationCallbacks = [];
+    this.onExtensionBroadcastCallbacks = [];
+    this.onCellSetBroadcastCallbacks = [];
 
     // GameState object for storing the game state/player location.
     // this.gameState = new GameState(gameMap);
@@ -94,7 +95,7 @@ class AllAreaBroadcaster {
    * message from redis.
    */
   registerOnLocation(callback) {
-    this.onLocation = callback;
+    this.onLocationCallbacks.push(callback);
   }
 
   /**
@@ -103,7 +104,7 @@ class AllAreaBroadcaster {
    * broadcast from redis.
    */
   registerOnExtensionBroadcast(callback) {
-    this.onExtensionBroadcast = callback;
+    this.onExtensionBroadcastCallbacks.push(callback);
   }
 
   /**
@@ -112,7 +113,37 @@ class AllAreaBroadcaster {
    * set modification broadcast from redis.
    */
   registerOnCellSetBroadcast(callback) {
-    this.onCellSetBroadcast = callback;
+    this.onCellSetBroadcastCallbacks.push(callback);
+  }
+
+  /**
+   * This is called when we've a location message from redis.
+   * @param {object} loc - The location object, see Gateway Service for doc.
+   */
+  onLocation(loc) {
+    for (const cb of this.onLocationCallbacks) {
+      cb(loc);
+    }
+  }
+
+  /**
+   * This is called when we've an extension broadcast from redis.
+   * @param {object} bc - The broadcast message.
+   */
+  onExtensionBroadcast(bc) {
+    for (const cb of this.onExtensionBroadcastCallbacks) {
+      cb(bc);
+    }
+  }
+
+  /**
+   * This is called when we've a cell set modification broadcast from redis.
+   * @param {object} cset - The cell set.
+   */
+  onCellSetBroadcast(cset) {
+    for (const cb of this.onCellSetBroadcastCallbacks) {
+      cb(cset);
+    }
   }
 
   /**

--- a/services/standalone/standalone-extension.mjs
+++ b/services/standalone/standalone-extension.mjs
@@ -40,6 +40,8 @@ async function standaloneExtensionServer() {
   const broadcaster = new AllAreaBroadcaster(rpcDirectory, gameMap, gameState);
   const extensionManager = new ExtensionManager(rpcDirectory, broadcaster, gameMap, null);
 
+  await broadcaster.initialize();
+
   if (!('ext' in argv)) {
     console.error('Please specify extension name via --ext argument.');
     process.exit();


### PR DESCRIPTION
1. Allow extensions (and probably anyone with the access to `AllAreaBroadcaster`) to register a listener on `onLocation` and `onCellSetBroadcast`.
2. Fix some bugs in the asset server and the standalone service.
3. Update `cellsettest` to test if `onLocation` and `onCellSetBroadcast` are working as expected.

By the way, do we need an unregister method? While it might be good to have one, I currently can't think up of any use case for it. 