### PR TITLE
Add player context menu

### DIFF
--- a/extensions/playerlist/common/client.mjs
+++ b/extensions/playerlist/common/client.mjs
@@ -36,7 +36,7 @@ class Client {
     this.toolbarButton = new ToolbarButton('/static/extensions/playerlist/common/playerlist.svg');
     this.toolbarButton.registerAsToggle(this.overlay);
     this.toolbarButton.show();
-   
+
     this.showPlayerList();
   }
 
@@ -54,7 +54,7 @@ class Client {
         }
         // TODO(zeze-zeze): Keep a record of dom elements
         // TODO(zeze-zeze): Move it to a separate function
-        document.getElementById('playerlist').innerHTML += '<span class="playerName" onclick="startPrivateMessage(\'' + playerID.playerID + '\')">' + this.HTMLEncode(playerID.displayName); + '</span>';
+        document.getElementById('playerlist').innerHTML += '<span class="playerName" data-player-context-menu=\'' + playerID.playerID + '\' onclick="startPrivateMessage(\'' + playerID.playerID + '\')">' + this.HTMLEncode(playerID.displayName); + '</span>';
 
         // TODO(zeze-zeze): Use onchange callback to update playerlist instead of waiting 1 second
      });

--- a/sites/game-client/client.css
+++ b/sites/game-client/client.css
@@ -164,3 +164,39 @@ body {
 #error-modal > div {
   width: 50%;
 }
+
+/* Context Menu */
+.context-menu {
+  padding: 0;
+  margin: 0;
+  position: absolute;
+  z-index: 1000;
+  display: none;
+}
+.context-menu-list {
+  display: flex;
+  flex-direction: column;
+  background-color: #fff;
+  border-radius: 3px;
+  box-shadow: 0 10px 20px rgb(64 64 64 / 5%);
+  padding: 3px 0;
+  margin: 0;
+  list-style: none;
+}
+.context-menu-list > li > a {
+  border: 0;
+  padding: 6px 15px 6px 15px;
+  width: 100%;
+  display: flex;
+  align-items: center;
+  position: relative;
+  text-decoration: unset;
+  color: #000;
+  font-weight: 500;
+  transition: 0.15s linear;
+  box-sizing: border-box;
+}
+.context-menu-list > li > a:hover {
+  background-color: #f1f3f7;
+  color: #4b00ff;
+}

--- a/sites/game-client/client.ejs
+++ b/sites/game-client/client.ejs
@@ -35,7 +35,7 @@ absolute URL.
             <p id="error-message"></p>
           </div>
           <p id="error-handler-message"></p>
-        </div> 
+        </div>
         <% inDiv.forEach((i) => { %>
           <%- include(i); %>
         <% }); %>
@@ -58,6 +58,13 @@ absolute URL.
       <div id="modal-background" class="modal-background">
       </div>
       <div id="modal-container" class="modal-container">
+      </div>
+      <!-- context menu -->
+      <div id="context-menu-other" class="context-menu">
+        <ul id="context-menu-list-other" class="context-menu-list"></ul>
+      </div>
+      <div id="context-menu-self" class="context-menu">
+        <ul id="context-menu-list-self" class="context-menu-list"></ul>
       </div>
     </div>
 
@@ -149,6 +156,8 @@ absolute URL.
             game.errorModal.displayError(reason, "Please refresh to reconnect.");
           }
         });
+
+        game.mainUI.createContextMenu(game.gameState, game.mapRenderer);
 
         function onGameTick () {
           game.mapRenderer.draw();

--- a/sites/game-client/ui/context-menu.mjs
+++ b/sites/game-client/ui/context-menu.mjs
@@ -26,7 +26,7 @@ class ContextMenu {
 
     // bind the contextmenu and click event.
     $('#mapcanvas').on('contextmenu', this.canvasOnContextMenu.bind(this));
-    $('body').on('contextmenu', '[data-player-context-menu]', (e) => this.elementOnContextMenu(e));
+    $('body').on('contextmenu', '[data-player-context-menu]', this.elementOnContextMenu.bind(this));
     $('body').on('click', this.hideMenu);
 
     // Get current player
@@ -84,15 +84,17 @@ class ContextMenu {
     }
 
     let menu = document.getElementById(div);
-    if (menu.style.display == "block") {
-      // If the menu is already opened, closed it.
+
+    // If the menu is already opened, closed it.
+    if (document.getElementById(CONTEXT_MENU_SELF_DIV).style.display == "block" ||
+        document.getElementById(CONTEXT_MENU_OTHER_DIV).style.display == "block") {
       this.hideMenu();
-    } else {
-      // Open the menu
-      menu.style.display = 'block';
-      menu.style.left = e.pageX + "px";
-      menu.style.top = e.pageY + "px";
     }
+
+    // Open the menu
+    menu.style.display = 'block';
+    menu.style.left = e.pageX + "px";
+    menu.style.top = e.pageY + "px";
   }
 
   /**

--- a/sites/game-client/ui/context-menu.mjs
+++ b/sites/game-client/ui/context-menu.mjs
@@ -139,6 +139,11 @@ class ContextMenu {
         document.getElementById(CONTEXT_MENU_LIST_SELF_UL).appendChild(newItemDOM);
     }
 
+    /**
+     * Handle the callback of the item.
+     * @param name The name of the clicked item.
+     * @param menuType others or self.
+     */
     handleCallback(name, menuType) {
         if (menuType === 'others' && this.othersMenu.get(name)) {
             return this.othersMenu.get(name)(this.focusedPlayer);

--- a/sites/game-client/ui/context-menu.mjs
+++ b/sites/game-client/ui/context-menu.mjs
@@ -1,0 +1,152 @@
+// Copyright 2021 HITCON Online Contributors
+// SPDX-License-Identifier: BSD-2-Clause
+
+const CONTEXT_MENU_OTHER_DIV = 'context-menu-other';
+const CONTEXT_MENU_LIST_OTHER_UL = 'context-menu-list-other';
+const CONTEXT_MENU_SELF_DIV = 'context-menu-self';
+const CONTEXT_MENU_LIST_SELF_UL = 'context-menu-list-self';
+
+const mapCellSize = 32;
+
+/**
+ * Maintain the state of the context menu for players.
+*/
+class ContextMenu {
+    /**
+     *
+     */
+    constructor(gameState, mapRenderer) {
+        this.gameState = gameState;
+        this.mapRenderer = mapRenderer;
+        this.othersMenu = new Map();
+        this.selfMenu = new Map();
+
+        this.focusedPlayer = null;
+        this.playerInfo = null;
+
+        // bind the contextmenu and click event.
+        document.getElementById('mapcanvas').addEventListener('contextmenu', this.onContextMenu.bind(this));
+        document.body.addEventListener('click', this.hideMenu);
+
+        // Get current player
+        window.addEventListener('gameStart', (d) => {
+            this.playerInfo = d.detail.gameClient.playerInfo;
+        });
+    }
+
+    /**
+     * Called when user clicked on the player.
+     * @param {Event} e event
+     */
+    onContextMenu(e) {
+        e.preventDefault();
+
+        // Check if the user actually clicked on a player.
+        if (!this.findFocusedUser(e.pageX, e.pageY)) {
+            return;
+        }
+
+        // Identify whether the menu is for the user itself or other players.
+        // Stop if the menu is empty.
+        let div;
+        if (this.focusedPlayer.playerID === this.playerInfo.playerID && this.selfMenu.size > 0) {
+            div = CONTEXT_MENU_SELF_DIV;
+        } else if (this.focusedPlayer.playerID !== this.playerInfo.playerID && this.othersMenu.size > 0) {
+            div = CONTEXT_MENU_OTHER_DIV;
+        } else {
+            this.focusedPlayer = null;
+            return;
+        }
+
+        let menu = document.getElementById(div);
+        if (menu.style.display == "block") {
+            this.hideMenu();
+        } else {
+            menu.style.display = 'block';
+            menu.style.left = e.pageX + "px";
+            menu.style.top = e.pageY + "px";
+        }
+
+    }
+
+    /**
+     * Hide menu
+     */
+    hideMenu() {
+        document.getElementById(CONTEXT_MENU_SELF_DIV).style.display = "none";
+        document.getElementById(CONTEXT_MENU_OTHER_DIV).style.display = "none";
+        this.focusedPlayer = null;
+    }
+
+    /**
+     * Find the player at the specific position in the page, and assign to this.focusedPlayer
+     * @param pageX Event.pageX
+     * @param pageY Event.pageX
+     * @returns {Boolean} Whether there exist a player at the position.
+     */
+    findFocusedUser(pageX, pageY) {
+        const x = pageX - this.mapRenderer.canvas.offsetLeft;
+        const y = pageY - this.mapRenderer.canvas.offsetTop;
+        for (const player of this.gameState.players.values()) {
+            const mapCoord = player.getDrawInfo()?.mapCoord;
+            const canvasCoordinate = this.mapRenderer.mapToCanvasCoordinate(mapCoord);
+
+            if (canvasCoordinate.x <= x &&
+                canvasCoordinate.x + mapCellSize >= x &&
+                canvasCoordinate.y >= y &&
+                canvasCoordinate.y - mapCellSize <= y
+            ) {
+              this.focusedPlayer = player;
+              return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Add a item to the context menu for other player.
+     * @param {string} name The displayed name of the item.
+     * @param {Function} callback A callback function which takes a Player object.
+     */
+    addToOthersMenu(name, callback) {
+        this.othersMenu.set(name, callback);
+
+        const newItemDOM = document.createElement('li');
+        newItemDOM.setAttribute('id', `context-menu-others-${this.othersMenu.size}`);
+        newItemDOM.innerHTML = `<a href="#">${name}</a></li>`;
+        newItemDOM.addEventListener('click', () => {
+            this.handleCallback(name, 'others');
+        });
+
+        document.getElementById(CONTEXT_MENU_LIST_OTHER_UL).appendChild(newItemDOM);
+    }
+    /**
+     * Add a item to the context menu for oneself.
+     * @param {string} name The displayed name of the item.
+     * @param {Function} callback A callback function which takes a Player object.
+     */
+    addToSelfMenu(name, callback) {
+        this.selfMenu.set(name, callback);
+
+        const newItemDOM = document.createElement('li');
+        newItemDOM.setAttribute('id', `context-menu-self-${this.selfMenu.size}`);
+        newItemDOM.innerHTML = `<a href="#">${name}</a></li>`;
+        newItemDOM.addEventListener('click', () => {
+            this.handleCallback(name, 'self');
+        });
+
+        document.getElementById(CONTEXT_MENU_LIST_SELF_UL).appendChild(newItemDOM);
+    }
+
+    handleCallback(name, menuType) {
+        if (menuType === 'others' && this.othersMenu.get(name)) {
+            return this.othersMenu.get(name)(this.focusedPlayer);
+        } else if (menuType === 'self' && this.selfMenu.get(name)) {
+            return this.selfMenu.get(name)(this.focusedPlayer);
+        }
+    }
+
+}
+
+export default ContextMenu;

--- a/sites/game-client/ui/context-menu.mjs
+++ b/sites/game-client/ui/context-menu.mjs
@@ -12,145 +12,145 @@ const mapCellSize = 32;
  * Maintain the state of the context menu for players.
 */
 class ContextMenu {
-    /**
-     *
-     */
-    constructor(gameState, mapRenderer) {
-        this.gameState = gameState;
-        this.mapRenderer = mapRenderer;
-        this.othersMenu = new Map();
-        this.selfMenu = new Map();
+  /**
+   *
+   */
+  constructor(gameState, mapRenderer) {
+    this.gameState = gameState;
+    this.mapRenderer = mapRenderer;
+    this.othersMenu = new Map();
+    this.selfMenu = new Map();
 
-        this.focusedPlayer = null;
-        this.playerInfo = null;
+    this.focusedPlayer = null;
+    this.playerInfo = null;
 
-        // bind the contextmenu and click event.
-        document.getElementById('mapcanvas').addEventListener('contextmenu', this.onContextMenu.bind(this));
-        document.body.addEventListener('click', this.hideMenu);
+    // bind the contextmenu and click event.
+    document.getElementById('mapcanvas').addEventListener('contextmenu', this.onContextMenu.bind(this));
+    document.body.addEventListener('click', this.hideMenu);
 
-        // Get current player
-        window.addEventListener('gameStart', (d) => {
-            this.playerInfo = d.detail.gameClient.playerInfo;
-        });
+    // Get current player
+    window.addEventListener('gameStart', (d) => {
+      this.playerInfo = d.detail.gameClient.playerInfo;
+    });
+  }
+
+  /**
+   * Called when user clicked on the player.
+   * @param {Event} e event
+   */
+  onContextMenu(e) {
+    e.preventDefault();
+
+    // Check if the user actually clicked on a player.
+    if (!this.findFocusedUser(e.pageX, e.pageY)) {
+      return;
     }
 
-    /**
-     * Called when user clicked on the player.
-     * @param {Event} e event
-     */
-    onContextMenu(e) {
-        e.preventDefault();
-
-        // Check if the user actually clicked on a player.
-        if (!this.findFocusedUser(e.pageX, e.pageY)) {
-            return;
-        }
-
-        // Identify whether the menu is for the user itself or other players.
-        // Stop if the menu is empty.
-        let div;
-        if (this.focusedPlayer.playerID === this.playerInfo.playerID && this.selfMenu.size > 0) {
-            div = CONTEXT_MENU_SELF_DIV;
-        } else if (this.focusedPlayer.playerID !== this.playerInfo.playerID && this.othersMenu.size > 0) {
-            div = CONTEXT_MENU_OTHER_DIV;
-        } else {
-            this.focusedPlayer = null;
-            return;
-        }
-
-        let menu = document.getElementById(div);
-        if (menu.style.display == "block") {
-            this.hideMenu();
-        } else {
-            menu.style.display = 'block';
-            menu.style.left = e.pageX + "px";
-            menu.style.top = e.pageY + "px";
-        }
-
+    // Identify whether the menu is for the user itself or other players.
+    // Stop if the menu is empty.
+    let div;
+    if (this.focusedPlayer.playerID === this.playerInfo.playerID && this.selfMenu.size > 0) {
+      div = CONTEXT_MENU_SELF_DIV;
+    } else if (this.focusedPlayer.playerID !== this.playerInfo.playerID && this.othersMenu.size > 0) {
+      div = CONTEXT_MENU_OTHER_DIV;
+    } else {
+      this.focusedPlayer = null;
+      return;
     }
 
-    /**
-     * Hide menu
-     */
-    hideMenu() {
-        document.getElementById(CONTEXT_MENU_SELF_DIV).style.display = "none";
-        document.getElementById(CONTEXT_MENU_OTHER_DIV).style.display = "none";
-        this.focusedPlayer = null;
+    let menu = document.getElementById(div);
+    if (menu.style.display == "block") {
+      this.hideMenu();
+    } else {
+      menu.style.display = 'block';
+      menu.style.left = e.pageX + "px";
+      menu.style.top = e.pageY + "px";
     }
 
-    /**
-     * Find the player at the specific position in the page, and assign to this.focusedPlayer
-     * @param pageX Event.pageX
-     * @param pageY Event.pageX
-     * @returns {Boolean} Whether there exist a player at the position.
-     */
-    findFocusedUser(pageX, pageY) {
-        const x = pageX - this.mapRenderer.canvas.offsetLeft;
-        const y = pageY - this.mapRenderer.canvas.offsetTop;
-        for (const player of this.gameState.players.values()) {
-            const mapCoord = player.getDrawInfo()?.mapCoord;
-            const canvasCoordinate = this.mapRenderer.mapToCanvasCoordinate(mapCoord);
+  }
 
-            if (canvasCoordinate.x <= x &&
-                canvasCoordinate.x + mapCellSize >= x &&
-                canvasCoordinate.y >= y &&
-                canvasCoordinate.y - mapCellSize <= y
-            ) {
-              this.focusedPlayer = player;
-              return true;
-            }
-        }
-        return false;
+  /**
+   * Hide menu
+   */
+  hideMenu() {
+    document.getElementById(CONTEXT_MENU_SELF_DIV).style.display = "none";
+    document.getElementById(CONTEXT_MENU_OTHER_DIV).style.display = "none";
+    this.focusedPlayer = null;
+  }
+
+  /**
+   * Find the player at the specific position in the page, and assign to this.focusedPlayer
+   * @param pageX Event.pageX
+   * @param pageY Event.pageX
+   * @returns {Boolean} Whether there exist a player at the position.
+   */
+  findFocusedUser(pageX, pageY) {
+    const x = pageX - this.mapRenderer.canvas.offsetLeft;
+    const y = pageY - this.mapRenderer.canvas.offsetTop;
+    for (const player of this.gameState.players.values()) {
+      const mapCoord = player.getDrawInfo()?.mapCoord;
+      const canvasCoordinate = this.mapRenderer.mapToCanvasCoordinate(mapCoord);
+
+      if (canvasCoordinate.x <= x &&
+        canvasCoordinate.x + mapCellSize >= x &&
+        canvasCoordinate.y >= y &&
+        canvasCoordinate.y - mapCellSize <= y
+      ) {
+        this.focusedPlayer = player;
+        return true;
+      }
     }
+    return false;
+  }
 
 
-    /**
-     * Add a item to the context menu for other player.
-     * @param {string} name The displayed name of the item.
-     * @param {Function} callback A callback function which takes a Player object.
-     */
-    addToOthersMenu(name, callback) {
-        this.othersMenu.set(name, callback);
+  /**
+   * Add a item to the context menu for other player.
+   * @param {string} name The displayed name of the item.
+   * @param {Function} callback A callback function which takes a Player object.
+   */
+  addToOthersMenu(name, callback) {
+    this.othersMenu.set(name, callback);
 
-        const newItemDOM = document.createElement('li');
-        newItemDOM.setAttribute('id', `context-menu-others-${this.othersMenu.size}`);
-        newItemDOM.innerHTML = `<a href="#">${name}</a></li>`;
-        newItemDOM.addEventListener('click', () => {
-            this.handleCallback(name, 'others');
-        });
+    const newItemDOM = document.createElement('li');
+    newItemDOM.setAttribute('id', `context-menu-others-${this.othersMenu.size}`);
+    newItemDOM.innerHTML = `<a href="#">${name}</a></li>`;
+    newItemDOM.addEventListener('click', () => {
+      this.handleCallback(name, 'others');
+    });
 
-        document.getElementById(CONTEXT_MENU_LIST_OTHER_UL).appendChild(newItemDOM);
+    document.getElementById(CONTEXT_MENU_LIST_OTHER_UL).appendChild(newItemDOM);
+  }
+  /**
+   * Add a item to the context menu for oneself.
+   * @param {string} name The displayed name of the item.
+   * @param {Function} callback A callback function which takes a Player object.
+   */
+  addToSelfMenu(name, callback) {
+    this.selfMenu.set(name, callback);
+
+    const newItemDOM = document.createElement('li');
+    newItemDOM.setAttribute('id', `context-menu-self-${this.selfMenu.size}`);
+    newItemDOM.innerHTML = `<a href="#">${name}</a></li>`;
+    newItemDOM.addEventListener('click', () => {
+      this.handleCallback(name, 'self');
+    });
+
+    document.getElementById(CONTEXT_MENU_LIST_SELF_UL).appendChild(newItemDOM);
+  }
+
+  /**
+   * Handle the callback of the item.
+   * @param name The name of the clicked item.
+   * @param menuType others or self.
+   */
+  handleCallback(name, menuType) {
+    if (menuType === 'others' && this.othersMenu.get(name)) {
+      return this.othersMenu.get(name)(this.focusedPlayer);
+    } else if (menuType === 'self' && this.selfMenu.get(name)) {
+      return this.selfMenu.get(name)(this.focusedPlayer);
     }
-    /**
-     * Add a item to the context menu for oneself.
-     * @param {string} name The displayed name of the item.
-     * @param {Function} callback A callback function which takes a Player object.
-     */
-    addToSelfMenu(name, callback) {
-        this.selfMenu.set(name, callback);
-
-        const newItemDOM = document.createElement('li');
-        newItemDOM.setAttribute('id', `context-menu-self-${this.selfMenu.size}`);
-        newItemDOM.innerHTML = `<a href="#">${name}</a></li>`;
-        newItemDOM.addEventListener('click', () => {
-            this.handleCallback(name, 'self');
-        });
-
-        document.getElementById(CONTEXT_MENU_LIST_SELF_UL).appendChild(newItemDOM);
-    }
-
-    /**
-     * Handle the callback of the item.
-     * @param name The name of the clicked item.
-     * @param menuType others or self.
-     */
-    handleCallback(name, menuType) {
-        if (menuType === 'others' && this.othersMenu.get(name)) {
-            return this.othersMenu.get(name)(this.focusedPlayer);
-        } else if (menuType === 'self' && this.selfMenu.get(name)) {
-            return this.selfMenu.get(name)(this.focusedPlayer);
-        }
-    }
+  }
 
 }
 

--- a/sites/game-client/ui/main-ui.mjs
+++ b/sites/game-client/ui/main-ui.mjs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 import OverlayPosition from './overlay-position.mjs';
+import ContextMenu from './context-menu.mjs';
 
 // enum
 const UIState = Object.freeze({
@@ -33,6 +34,7 @@ class MainUI {
     this.state = UIState.NORMAL_UI;
     this.overlays = new Map();
     this.activeModal = undefined;
+    this.mapRenderer = undefined;
 
     window.addEventListener('resize', (evt) => { this._onResize(evt); });
     window.addEventListener('gameStart', (evt) => { this._onResize(evt); });
@@ -66,6 +68,15 @@ class MainUI {
    */
   showNotification(msg, timeout) {
     // TODO(lisasasasa)
+  }
+
+  /**
+   * Initiate the context menu.
+   * @param {GameState} gameState - The GameState object.
+   * @param {MapRenderer} mapRenderer
+   */
+  createContextMenu(gameState, mapRenderer) {
+    this.contextMenu = new ContextMenu(gameState, mapRenderer);
   }
 
   // If we want to use individual overlay for meeting


### PR DESCRIPTION
As title.

One can use the following code to register a context menu item in an extension.
```js
// This item is only shown when right-clicking on other players.
this.helper.mainUI.contextMenu.addToOthersMenu('test', (player) => console.log(player));

// This item is only shown when right-clicking on oneself.
this.helper.mainUI.contextMenu.addToSelfMenu('test', (player) => console.log(player));
```

I prefer merging this PR before PR #134, so that I can implement the point system in a single PR.