### PR TITLE
Fix 駭客貓歷險記 issues in the production mode

### DIFF
--- a/.pnp.js
+++ b/.pnp.js
@@ -2587,6 +2587,7 @@ function $$SETUP_STATE(hydrateRuntimeState, basePath) {
             ["hitcon-online-escape-game", "workspace:extensions/escape-game"],
             ["@grpc/grpc-js", "npm:1.3.7"],
             ["@grpc/proto-loader", "npm:0.6.4"],
+            ["config", "npm:3.3.6"],
             ["jsonwebtoken", "npm:8.5.1"]
           ],
           "linkType": "SOFT",

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     command:  bash -c "yarn && ./run-all.sh"
     depends_on:
       - redis
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
 
   redis:
     image: redis
@@ -24,3 +26,5 @@ services:
     depends_on:
       - online
       - redis
+    extra_hosts:
+      - "host.docker.internal:host-gateway"

--- a/docker/generate-nginx-conf.py
+++ b/docker/generate-nginx-conf.py
@@ -17,5 +17,6 @@ Path(f'{run_dir}/nginx.conf').touch()
 Path(f'{run_dir}/nginx.conf').write_text(template.format(
     publicAddress=config['publicAddress'],
     online='online:' + str(config['assetServer']['port']),
+    terminal=str(config['terminal']['internalAddress']) + ':' + str(config['terminal']['socketioPort']),
     gateways=''.join([f"\n        server online:{v['httpAddress'].split(':')[1]}; # {k}" for k, v in config['gatewayServers'].items()])
 ))

--- a/extensions/dialog/common/client.mjs
+++ b/extensions/dialog/common/client.mjs
@@ -29,7 +29,8 @@ class DialogModal extends Modal {
     let triggered = false;
     const p = new Promise((resolve, reject) => {
       for (const btns of btnList) {
-        for (const btn of btns) {
+        const btns_ = HTMLCollection.prototype.isPrototypeOf(btns) ? btns : [btns];
+        for (const btn of btns_) {
           const f = (btn) => {
             // Extra layer of closure so we can pass btn in.
             return () => {

--- a/extensions/escape-game/common/client.mjs
+++ b/extensions/escape-game/common/client.mjs
@@ -7,7 +7,6 @@ import InteractiveObjectClientBaseClass from '/static/common/interactive-object/
 
 const TERMINAL_CONTAINER = 'terminal-container';
 const TERMINAL_DIV = 'terminal';
-const TERMINAL_SERVER = '127.0.0.1:5050';
 
 class TerminalModal extends Modal {
   constructor(mainUI) {
@@ -67,6 +66,7 @@ class Client {
     this.socket = null;
     this.term = null;
     this.roomId = null;
+    this.terminalServerAddress = null;
 
     this.terminals = new Map();
   }
@@ -80,6 +80,9 @@ class Client {
       const clientInfo = await this.helper.callC2sAPI('escape-game', 'getTerminalClientInfo', this.helper.defaultTimeout, terminalId);
       this.terminals.set(terminalId, new TerminalObject(this.helper, terminalId, clientInfo));
     }
+
+    this.terminalServerAddress = await this.helper.callC2sAPI('escape-game', 'getTerminalServerAddress', this.helper.defaultTimeout);
+    console.log(this.terminalServerAddress);
   }
 
   /**
@@ -93,7 +96,7 @@ class Client {
     this.term = new Terminal({cursorBlink: true});
     this.term.open(document.getElementById(TERMINAL_DIV));
 
-    this.socket = window.io(TERMINAL_SERVER, {reconnection: false});
+    this.socket = window.io(this.terminalServerAddress, {reconnection: false});
 
     this.socket.on('connect', () => {
       this.term.write('\r\n*** Connected ***\r\n');

--- a/extensions/escape-game/common/client.mjs
+++ b/extensions/escape-game/common/client.mjs
@@ -82,7 +82,6 @@ class Client {
     }
 
     this.terminalServerAddress = await this.helper.callC2sAPI('escape-game', 'getTerminalServerAddress', this.helper.defaultTimeout);
-    console.log(this.terminalServerAddress);
   }
 
   /**

--- a/extensions/escape-game/package.json
+++ b/extensions/escape-game/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.3.7",
     "@grpc/proto-loader": "^0.6.4",
+    "config": "^3.3.6",
     "jsonwebtoken": "^8.5.1"
   }
 }

--- a/extensions/escape-game/standalone.mjs
+++ b/extensions/escape-game/standalone.mjs
@@ -423,7 +423,6 @@ class Standalone {
       this.helper.callS2cAPI(playerID, 'dialog', 'showDialog', 60*1000,
         sfInfo.name, 'Team created, the invitation code is: ' + this.teams.get(teamId).invitationCode);
 
-      console.log(nextState);
       return nextState;
     } catch (e) {
       console.error(e);

--- a/run/config/default.json
+++ b/run/config/default.json
@@ -49,8 +49,10 @@
     "prefix": "hitcon"
   },
   "terminal": {
-    "grpcAddress": "127.0.0.1:5051",
-    "publicAddress": "127.0.0.1:5050"
+    "internalAddress": "localhost",
+    "grpcPort": 5051,
+    "publicAddress": "localhost",
+    "socketioPort": 5050
   },
   "publicAddress": null,
   "movingRequestThreshold": 100

--- a/run/config/default.json
+++ b/run/config/default.json
@@ -48,6 +48,10 @@
     "hmacSecret": "secret",
     "prefix": "hitcon"
   },
+  "terminal": {
+    "grpcAddress": "127.0.0.1:5051",
+    "publicAddress": "127.0.0.1:5050"
+  },
   "publicAddress": null,
   "movingRequestThreshold": 100
 }

--- a/run/config/production.json
+++ b/run/config/production.json
@@ -41,7 +41,8 @@
       "npc",
       "playerlist",
       "iframe",
-      "escape-room"
+      "escape-game",
+      "jitsi"
     ],
     "standalone": {
       "chat": "127.0.0.1:5020",
@@ -56,8 +57,19 @@
       "npc": "127.0.0.1:5029",
       "playerlist": "127.0.0.1:5030",
       "iframe": "127.0.0.1:5031",
-      "escape-room": "127.0.0.1:5032"
+      "escape-game": "127.0.0.1:5032",
+      "jitsi": "127.0.0.1:5033"
     }
+  },
+  "jitsi": {
+    "hmacSecret": "secret",
+    "prefix": "hitcon"
+  },
+  "terminal": {
+    "internalAddress": "host.docker.internal",
+    "grpcPort": 5051,
+    "publicAddress": "online.hitcon.org",
+    "socketioPort": 5050
   },
   "publicAddress": "online.hitcon.org",
   "movingRequestThreshold": 100

--- a/yarn.lock
+++ b/yarn.lock
@@ -1953,6 +1953,7 @@ __metadata:
   dependencies:
     "@grpc/grpc-js": ^1.3.7
     "@grpc/proto-loader": ^0.6.4
+    config: ^3.3.6
     jsonwebtoken: ^8.5.1
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
1. Make sure that the terminal server works in the production mode [1].
2. Add error handlers in the FSM of 駭客貓歷險記, so that error status won't crash the team manager.
3. Fix some random bugs in 駭客貓歷險記.
4. Fix an issue in dialog, which crash when the `btns` value is not iterable (i.e. HTMLCollections).

[1] Since the terminal server requires access to docker, and it's difficult to access docker in docker container (linking docker.sock into the container is usually a terrible idea), I believe running terminal server separately, not putting it in `/docker/docker-compose.yml` is a better solution. However, this indicates that the `online` container can access the host network :( 
Calling for better ideas.