### PR TITLE
Fix some minor issues so that the escape-game extension and docker-compose

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "../:/home/node/app"
       - "${RUN_DIR:-../run}:/home/node/app/run"
     command:  bash -c "yarn && ./run-all.sh"
+    user: "${_UID}:${_GID}"
     depends_on:
       - redis
     extra_hosts:

--- a/docker/generate-nginx-conf.py
+++ b/docker/generate-nginx-conf.py
@@ -17,6 +17,5 @@ Path(f'{run_dir}/nginx.conf').touch()
 Path(f'{run_dir}/nginx.conf').write_text(template.format(
     publicAddress=config['publicAddress'],
     online='online:' + str(config['assetServer']['port']),
-    terminal=str(config['terminal']['internalAddress']) + ':' + str(config['terminal']['socketioPort']),
     gateways=''.join([f"\n        server online:{v['httpAddress'].split(':')[1]}; # {k}" for k, v in config['gatewayServers'].items()])
 ))

--- a/extensions/escape-game/common/client.mjs
+++ b/extensions/escape-game/common/client.mjs
@@ -95,7 +95,7 @@ class Client {
     this.term = new Terminal({cursorBlink: true});
     this.term.open(document.getElementById(TERMINAL_DIV));
 
-    this.socket = window.io(this.terminalServerAddress, {reconnection: false});
+    this.socket = window.io(this.terminalServerAddress.address, {reconnection: false, path: this.terminalServerAddress.path});
 
     this.socket.on('connect', () => {
       this.term.write('\r\n*** Connected ***\r\n');

--- a/extensions/escape-game/standalone.mjs
+++ b/extensions/escape-game/standalone.mjs
@@ -104,7 +104,7 @@ class Standalone {
     await this.helper.callS2sAPI('iobj-lib', 'reqRegister');
     this.terminalObjects.forEach((v) => {
       v.registerExtStateFunc('showTerminal', 'escape-game', 'sf_showTerminal');
-      v.registerExtStateFunc('checkStatus', 'escape-game', 'sf_checkStatus');
+      v.registerExtStateFunc('checkIsInFinalizedTeam', 'escape-game', 'sf_checkIsInFinalizedTeam');
     });
   }
 
@@ -364,7 +364,7 @@ class Standalone {
   /**
    * Check if the player is in a finalized team and therefore can access the game.
    */
-  async s2s_sf_checkStatus(srcExt, playerID, kwargs, sfInfo) {
+  async s2s_sf_checkIsInFinalizedTeam(srcExt, playerID, kwargs, sfInfo) {
     const {nextState, errorState} = kwargs;
 
     if (this.playerToTeam.has(playerID) && this.playerToTeam.get(playerID).isFinalized) {
@@ -387,7 +387,7 @@ class Standalone {
 
   // Team Manager
 
-  async s2s_sf_checkTeamStatus(srcExt, playerID, kwargs, sfInfo) {
+  async s2s_sf_checkIsInTeam(srcExt, playerID, kwargs, sfInfo) {
     const {indivMenu, teamMenu} = kwargs;
     return this.playerToTeam.has(playerID) ? teamMenu : indivMenu;
   }

--- a/extensions/escape-game/standalone.mjs
+++ b/extensions/escape-game/standalone.mjs
@@ -38,7 +38,7 @@ function getConfigWithDefault(entry, def) {
 }
 
 
-const TERMINAL_SERVER_GRPC_LOCATION = getConfigWithDefault('terminal.internalAddress', '127.0.0.1:5051') + ':' + getConfigWithDefault('terminal.grpcPort', 5051).toString();
+const TERMINAL_SERVER_GRPC_LOCATION = getConfigWithDefault('terminal.internalAddress', '127.0.0.1') + ':' + getConfigWithDefault('terminal.grpcPort', 5051).toString();
 
 /**
  * Terminology:
@@ -112,7 +112,10 @@ class Standalone {
    * Return the public address of the terminal server.
    */
   async c2s_getTerminalServerAddress(player) {
-    return getConfigWithDefault('terminal.publicAddress', '127.0.0.1') + ':' + getConfigWithDefault('terminal.socketioPort', 5000).toString();
+    return {
+      address: getConfigWithDefault('terminal.publicAddress', '127.0.0.1'),
+      path: getConfigWithDefault('terminal.socketioPath', '') + '/socket.io'
+    }
   }
 
   /**

--- a/run/config/default.json
+++ b/run/config/default.json
@@ -51,8 +51,8 @@
   "terminal": {
     "internalAddress": "localhost",
     "grpcPort": 5051,
-    "publicAddress": "localhost",
-    "socketioPort": 5050
+    "publicAddress": "localhost:5050",
+    "socketioPath": ""
   },
   "publicAddress": null,
   "movingRequestThreshold": 100

--- a/run/config/production.json
+++ b/run/config/production.json
@@ -69,7 +69,7 @@
     "internalAddress": "host.docker.internal",
     "grpcPort": 5051,
     "publicAddress": "online.hitcon.org",
-    "socketioPort": 5050
+    "socketioPath": "/terminal"
   },
   "publicAddress": "online.hitcon.org",
   "movingRequestThreshold": 100

--- a/run/npc/team-manager.json
+++ b/run/npc/team-manager.json
@@ -20,7 +20,7 @@
       "initialState": "baseState",
       "states": {
         "baseState": {
-          "func": "checkTeamStatus",
+          "func": "checkIsInTeam",
           "kwargs": {
             "indivMenu": "indivMenu",
             "teamMenu": "team1"

--- a/run/terminal/example-terminal1.json
+++ b/run/terminal/example-terminal1.json
@@ -23,7 +23,7 @@
     "initialState": "baseState",
     "states": {
       "baseState": {
-        "func": "checkStatus",
+        "func": "checkIsInFinalizedTeam",
         "kwargs": {
           "nextState": "s1",
           "errorState": "s2"

--- a/run/terminal/example-terminal2.json
+++ b/run/terminal/example-terminal2.json
@@ -23,7 +23,7 @@
     "initialState": "baseState",
     "states": {
       "baseState": {
-        "func": "checkStatus",
+        "func": "checkIsInFinalizedTeam",
         "kwargs": {
           "nextState": "s1",
           "errorState": "s2"


### PR DESCRIPTION
1. Change the way the escape-game extension handles the terminal server connection. (temporary changes, will revisit here when we decide to use a single Nginx instance.)
2. Allow changing the default uid & gid for the online container. This prevents that `yarn` is executed with root, causing some files in `.yarn` owned by root.