### PR TITLE
Fix multiple Jitsi issues

### DIFF
--- a/extensions/jitsi/common/client.mjs
+++ b/extensions/jitsi/common/client.mjs
@@ -94,12 +94,14 @@ class Client {
         this.microphoneButton.changeIcon('/static/extensions/jitsi/common/icons/microphone-off.svg');
         this.isMicrophoneOn = false;
         if (this.jitsiObj) {
+          this.jitsiObj.isMuted.audio = false;
           this.jitsiObj.mute('audio');
         }
       } else {
         this.microphoneButton.changeIcon('/static/extensions/jitsi/common/icons/microphone-on.svg');
         this.isMicrophoneOn = true;
         if (this.jitsiObj) {
+          this.jitsiObj.isMuted.audio = true;
           this.jitsiObj.unmute('audio');
         }
       }
@@ -114,12 +116,14 @@ class Client {
         this.cameraButton.changeIcon('/static/extensions/jitsi/common/icons/camera-off.svg');
         this.isCameraOn = false;
         if (this.jitsiObj) {
+          this.jitsiObj.isMuted.video = false;
           this.jitsiObj.mute('video');
         }
       } else {
         this.cameraButton.changeIcon('/static/extensions/jitsi/common/icons/camera-on.svg');
         this.isCameraOn = true;
         if (this.jitsiObj) {
+          this.jitsiObj.isMuted.video = true;
           this.jitsiObj.unmute('video');
         }
       }
@@ -138,7 +142,7 @@ class Client {
 
         if (this.jitsiObj) {
           this.jitsiObj.isWebcam = true;
-          this.jitsiObj.createLocalTracks();
+          this.jitsiObj.createLocalTrack('video');
         }
       } else {
         this.screenButton.changeIcon('/static/extensions/jitsi/common/icons/screen-on.svg');
@@ -150,8 +154,9 @@ class Client {
         this.cameraButton.changeIcon('/static/extensions/jitsi/common/icons/camera-off.svg');
 
         if (this.jitsiObj) {
+          this.jitsiObj.isMuted.video = true;
           this.jitsiObj.isWebcam = false;
-          this.jitsiObj.createLocalTracks();
+          this.jitsiObj.createLocalTrack('desktop');
         }
       }
     });
@@ -164,14 +169,14 @@ class Client {
       this.settingTab.addDropdown('device', 'video', '影像輸入', (value) => {
         console.log('device video', value);
         if (this.videoDevice !== value && this.jitsiObj) {
-          this.jitsiObj.createLocalTracks();
+          this.jitsiObj.createLocalTrack('video');
         }
         this.videoDevice = value;
       }, 0);
       this.settingTab.addDropdown('device', 'audio', '音訊輸入', (value) => {
         console.log('device audio', value);
         if (this.audioDevice !== value && this.jitsiObj) {
-          this.jitsiObj.createLocalTracks();
+          this.jitsiObj.createLocalTrack('audio');
         }
         this.audioDevice = value;
       }, 10);
@@ -193,14 +198,12 @@ class Client {
 
     this.jitsiObj = new JitsiHandler(realMeetingName, password,
       this.helper.gameClient.playerInfo.displayName, this.getDevices, this.setSettingDeviceOptions.bind(this));
+
+    this.jitsiObj.isMuted.audio = !this.isMicrophoneOn;
+    this.jitsiObj.isMuted.video = !this.isCameraOn;
+
     this.currentMeeting = meetingName;
     this.container.show();
-
-    this.isCameraOn = false;
-    this.cameraButton.changeIcon('/static/extensions/jitsi/common/icons/camera-off.svg');
-
-    this.isMicrophoneOn = false;
-    this.microphoneButton.changeIcon('/static/extensions/jitsi/common/icons/microphone-off.svg');
   }
 
   /**
@@ -212,6 +215,11 @@ class Client {
       await this.jitsiObj.unload();
       this.jitsiObj = undefined;
       this.currentMeeting = undefined;
+
+      // Set screen sharing to false.
+      this.screenButton.changeIcon('/static/extensions/jitsi/common/icons/screen-off.svg');
+      this.isScreenSharingOn = false;
+      this.cameraButton.show();
     }
   }
 

--- a/extensions/jitsi/common/client.mjs
+++ b/extensions/jitsi/common/client.mjs
@@ -41,15 +41,19 @@ class JitsiFullscreenOverlay extends Overlay {
     const dom = document.getElementById('jitsi-fullscreen-overlay');
     super(mainUI, dom);
     this.hide();
+    this.hasFullscreen = false;
 
     const self = this;
     $('#jitsi-remote-container').on('click', '.jitsi-user-container', function() {
+      if (self.hasFullscreen) return;
+      self.hasFullscreen = true;
       const focusedParticipantId = $(this).attr('data-id');
       $(this).find('video').eq(0).appendTo('#jitsi-fullscreen-overlay');
       self.show(OverlayPosition.LEFT_BOTTOM);
       mainUI.enterFocusMode(self, OverlayPosition.LEFT_BOTTOM, () => {
         $('#jitsi-fullscreen-overlay > video').appendTo(`#jitsi-${focusedParticipantId}-container > .jitsi-user-video`);
         self.hide();
+        self.hasFullscreen = false;
       });
     });
   }

--- a/extensions/jitsi/common/jitsi.mjs
+++ b/extensions/jitsi/common/jitsi.mjs
@@ -423,6 +423,7 @@ class JitsiHandler {
     if (this.room) {
       try {
         await this.room.leave();
+        this.room = undefined;
       } catch (e) {
         console.error(`Failed to unload jitsi room`, e, e.stack);
       }

--- a/extensions/jitsi/common/jitsi.mjs
+++ b/extensions/jitsi/common/jitsi.mjs
@@ -16,7 +16,7 @@ class JitsiHandler {
   constructor(meetingName, password, userName, getDevices, setSettingDeviceOptions) {
     this.connection = null;
     this.isVideo = true;
-    this.localTracks = [];
+    this.localTracks = {};
     this.remoteTracks = {};
     this.volumeMeters = {};
     this.participantsInfo = {};
@@ -30,6 +30,9 @@ class JitsiHandler {
     this.userName = userName;
     this.getDevices = getDevices;
     this.setSettingDeviceOptions = setSettingDeviceOptions;
+
+    // Is track mute
+    this.isMuted = {video: true, audio: true};
 
     this.options = {
       hosts: {
@@ -89,48 +92,25 @@ class JitsiHandler {
 
     this.connection.connect();
 
-    this.createLocalTracks();
+    $('#jitsi-local').empty();
   }
 
   /**
    * Create local track. This method would drop all current local tracks.
    */
-  async createLocalTracks() {
-    if (!this.isWebcam && !JitsiMeetJS.isDesktopSharingEnabled()) {
-      alert('Screen sharing is not enabled.');
+  async createLocalTrack(type) {
+    console.log('createLocalTrack', type);
+    if (!this.isWebcam && type === 'desktop' && !JitsiMeetJS.isDesktopSharingEnabled()) {
+      throw new Error('Screen sharing is not enabled.');
     }
-
-    // Drop the current local tracks.
-    try {
-      await Promise.all(this.localTracks.map(track => track.dispose()));
-    } catch (e) {
-      console.error('Failed to drop current local tracks: ', e);
-    }
-
-    this.localTracks = [];
-    $('#jitsi-local').empty();
 
     // Create new local tracks
-    try {
-      const tracks = await JitsiMeetJS.createLocalTracks({
-        devices: ['audio', this.isWebcam ? 'video' : 'desktop'],
-        cameraDeviceId: this.getDevices('video'),
-        micDeviceId: this.getDevices('audio')
-      });
-      await this.onLocalTracks(tracks);
-    } catch (e) {
-      console.error('Failed to create local tracks: ', e);
-      // if (!this.isWebcam) {
-      //   // something goes wrong, switch back to video.
-      //   console.warning('Fall back to video');
-      //   try {
-      //     this.isWebcam = true;
-      //     this.createLocalTracks();
-      //   } catch (e) {
-      //     console.error('Fall back to video failed: ', e);
-      //   }
-      // }
-    }
+    const tracks = await JitsiMeetJS.createLocalTracks({
+      devices: [type],
+      cameraDeviceId: this.getDevices('video'),
+      micDeviceId: this.getDevices('audio')
+    });
+    await this.onLocalTracks(tracks);
   }
 
   /**
@@ -147,15 +127,17 @@ class JitsiHandler {
         <div class='jitsi-user-audio'></div>
         <div class='jitsi-user-name' id='jitsi-local-user-name'></div>
       `);
+      $('#jitsi-local-user-name').text(this.userName);
     }
 
-    this.localTracks = tracks;
     for (const track of tracks) {
       const trackId = 'jitsi-local-track-' + track.getType();
       if (track.getType() === 'video') {
+        $('#jitsi-local > .jitsi-user-video').empty();
         $('#jitsi-local > .jitsi-user-video').append(`<video autoplay='1' id='${trackId}' class='jitsi-local-video' />`);
         track.attach($(`#${trackId}`)[0]);
       } else if (track.getType() === 'audio') {
+        $('#jitsi-local > .jitsi-user-audio').empty();
         $('#jitsi-local > .jitsi-user-audio').append(`<audio autoplay='1' muted='true' id='${trackId}' class='jitsi-audio' />`);
         track.attach($(`#${trackId}`)[0]);
       } else {
@@ -163,13 +145,13 @@ class JitsiHandler {
         continue;
       }
 
-      // All tracks should be disabled by default (except screen sharing), and enabled upon requested.
-      if (this.isWebcam || track.getType() !== 'video') {
+      // Check if the track should be muted, unless it is screen sharing.
+      if ((this.isWebcam || track.getType() !== 'video') && this.isMuted[track.getType()]) {
         track.mute();
       }
 
       // Add mute overlay
-      if (this.isWebcam || track.getType() !== 'video') {
+      if ((this.isWebcam || track.getType() !== 'video') && this.isMuted[track.getType()]) {
         $(`#jitsi-local > .jitsi-user-${track.getType()}`).addClass(`jitsi-user-${track.getType()}--close`);
         $(`#${trackId}`).css('display', 'none');
       } else {
@@ -180,9 +162,13 @@ class JitsiHandler {
         JitsiMeetJS.createTrackVADEmitter(track.getDeviceId(), 4096, await createRnnoiseProcessor());
       }
 
-      if (this.isJoined) {
+      if (track.getType() in this.localTracks) {
+        this.room.replaceTrack(this.localTracks[track.getType()], track);
+      } else {
         this.room.addTrack(track);
       }
+
+      this.localTracks[track.getType()] = track;
     }
   }
 
@@ -273,11 +259,20 @@ class JitsiHandler {
   onConferenceJoined() {
     console.log('conference joined!');
     this.isJoined = true;
-    for (let i = 0; i < this.localTracks.length; i++) {
-      this.room.addTrack(this.localTracks[i]);
+
+    try {
+      this.createLocalTrack('audio');
+    } catch (e) {
+      console.error('Failed to create audio track', e);
     }
+
+    try {
+      this.createLocalTrack(this.isWebcam ? 'video' : 'desktop');
+    } catch (e) {
+      console.error('Failed to create video track', e);
+    }
+
     $('#jitsi-local').addClass('active');
-    $('#jitsi-local-user-name').text(this.userName);
     this.setLocalAudioVolumeMeter();
   }
 
@@ -387,7 +382,6 @@ class JitsiHandler {
         const deviceList = devices
           .filter(m => m.kind === deviceType + 'input')
           .reduce((obj, item) => Object.assign(obj, {[item.deviceId]: item.label}), {});
-        console.log(devices, deviceList);
         setSettingDeviceOptions(deviceType, deviceList);
       });
     }
@@ -414,8 +408,8 @@ class JitsiHandler {
    */
   async unload() {
     if (this.localTracks) {
-      for (let i = 0; i < this.localTracks.length; i++) {
-        await this.localTracks[i].dispose();
+      for (const [type, track] of Object.entries(this.localTracks)) {
+        await track.dispose();
       }
     }
 
@@ -448,14 +442,17 @@ class JitsiHandler {
    * @param {string} type Which type to mute (audio|video)
    */
   async mute(type) {
-    for (const track of this.localTracks) {
-      if (track.getType() === type) {
-        track.mute();
-
-        $(`#jitsi-local > .jitsi-user-${track.getType()}`).addClass(`jitsi-user-${track.getType()}--close`);
-        $(`#jitsi-local-track-${track.getType()}`).css('display', 'none');
-      }
+    if (!(type in this.localTracks)) {
+      return;
     }
+
+    const track = this.localTracks[type];
+    this.isMuted[type] = true;
+
+    track.mute();
+    $(`#jitsi-local > .jitsi-user-${track.getType()}`).addClass(`jitsi-user-${track.getType()}--close`);
+    $(`#jitsi-local-track-${track.getType()}`).css('display', 'none');
+
   }
 
   /**
@@ -463,16 +460,19 @@ class JitsiHandler {
    * @param {string} type Which type to unmute (audio|video)
    */
   async unmute(type) {
-    for (const track of this.localTracks) {
-      if (track.getType() === type) {
-        track.unmute();
-
-        $(`#jitsi-local > .jitsi-user-${track.getType()}`).removeClass(`jitsi-user-${track.getType()}--close`);
-        if (track.getType() === 'video') {
-          $(`#jitsi-local-track-${track.getType()}`).css('display', 'block');
-        }
-      }
+    if (!(type in this.localTracks)) {
+      return;
     }
+
+    const track = this.localTracks[type];
+    this.isMuted[type] = false;
+
+    track.unmute();
+    $(`#jitsi-local > .jitsi-user-${track.getType()}`).removeClass(`jitsi-user-${track.getType()}--close`);
+    if (track.getType() === 'video') {
+      $(`#jitsi-local-track-${track.getType()}`).css('display', 'block');
+    }
+
   }
 
   /**
@@ -501,7 +501,7 @@ class JitsiHandler {
       const volumes = new Uint8Array(analyser.frequencyBinCount);
       volumeCallback = () => {
         // If the audio track is muted, return 0.
-        if (this.localTracks.filter(track => track.getType() === 'audio' && !track.isMuted()).length === 0) {
+        if (!('audio' in this.localTracks) || this.isMuted['audio']) {
           this.room?.setLocalParticipantProperty('volume', '0');
           $(`#jitsi-local`).removeClass('speaking');
           return;


### PR DESCRIPTION
1. The mute button now syncs between sessions.
2. Handle media track separately, so that users without webcam can still use audio.
3. Prevent multiple participants get fullscreened.