### PR TITLE
Several Jitsi fixes

### DIFF
--- a/extensions/jitsi/common/client.mjs
+++ b/extensions/jitsi/common/client.mjs
@@ -200,8 +200,14 @@ class Client {
       await new Promise(r => setTimeout(r, 1000));
     }
 
-    this.jitsiObj = new JitsiHandler(realMeetingName, password,
-      this.helper.gameClient.playerInfo.displayName, this.getDevices, this.setSettingDeviceOptions.bind(this));
+    this.jitsiObj = new JitsiHandler(
+      realMeetingName,
+      password,
+      this.helper.gameClient.playerInfo.displayName,
+      this.getDevices,
+      this.setSettingDeviceOptions.bind(this),
+      this.broadcastParticipantId.bind(this)
+    );
 
     this.jitsiObj.isMuted.audio = !this.isMicrophoneOn;
     this.jitsiObj.isMuted.video = !this.isCameraOn;
@@ -295,6 +301,20 @@ class Client {
     if (this.settingTab) {
       this.settingTab.updateDropdownOptions('device', deviceType, deviceList, currentDevice);
     }
+  }
+
+  async broadcastParticipantId(participantId) {
+    return await this.helper.callC2sAPI(null, 'updateIdMapping', this.helper.defaultTimeout, {
+      'participantId': participantId,
+      'meetingName': this.currentMeeting
+    });
+  }
+
+  async s2c_updateIdMapping(playerIdToParticipantIdMapping) {
+    if (this.jitsiObj) {
+      this.jitsiObj.updateMappingAndRemoveDanglingUser(playerIdToParticipantIdMapping);
+    }
+    return true;
   }
 };
 

--- a/extensions/jitsi/common/client.mjs
+++ b/extensions/jitsi/common/client.mjs
@@ -208,10 +208,7 @@ class Client {
     this.jitsiObj.connect(
       realMeetingName,
       password,
-      this.helper.gameClient.playerInfo.displayName,
-      this.getDevices,
-      this.setSettingDeviceOptions.bind(this),
-      this.broadcastParticipantId.bind(this)
+      this.helper.gameClient.playerInfo.displayName
     );
 
     this.jitsiObj.isMuted.audio = !this.isMicrophoneOn;

--- a/extensions/jitsi/common/client.mjs
+++ b/extensions/jitsi/common/client.mjs
@@ -310,7 +310,10 @@ class Client {
   }
 
   /**
-   *
+   * Update the list of dropdown options. This is called when Jitsi detect new input devices.
+   * @param {string} deviceType - The type of device. "audioinput", "videoinput" or "audiooutput"
+   * @param {Array} deviceList - The list of devices.
+   * @param {string} currentDevice - The selected option.
    */
   setSettingDeviceOptions(deviceType, deviceList, currentDevice) {
     if (this.settingTab) {
@@ -318,6 +321,10 @@ class Client {
     }
   }
 
+  /**
+   * Notify the standalone of the player's participant ID on Jitsi.
+   * @param participantId The player's participant ID on Jitsi.
+   */
   async broadcastParticipantId(participantId) {
     return await this.helper.callC2sAPI(null, 'updateIdMapping', this.helper.defaultTimeout, {
       'participantId': participantId,
@@ -325,9 +332,13 @@ class Client {
     });
   }
 
-  async s2c_updateIdMapping(playerIdToParticipantIdMapping) {
+  /**
+   * Notify the Jitsi Handler to update id mapping and remove the dangling user.
+   * @param playerIdToParticipantIdMapping The player ID to Participant ID mapping.
+   */
+  async s2c_updateIdMappingAndRemoveDanglingUser(playerIdToParticipantIdMapping) {
     if (this.jitsiObj) {
-      this.jitsiObj.updateMappingAndRemoveDanglingUser(playerIdToParticipantIdMapping);
+      this.jitsiObj.updateIdMappingAndRemoveDanglingUser(playerIdToParticipantIdMapping);
     }
     return true;
   }

--- a/extensions/jitsi/common/jitsi.mjs
+++ b/extensions/jitsi/common/jitsi.mjs
@@ -429,7 +429,7 @@ class JitsiHandler {
       }
     }
 
-    this.broadcastParticipantId(null); // broadcast that the player has quit.
+    await this.broadcastParticipantId(null); // broadcast that the player has quit.
 
     // We can safely remove all DOMs at this point.
     $('#jitsi-remote-container').empty();

--- a/extensions/jitsi/common/jitsi.mjs
+++ b/extensions/jitsi/common/jitsi.mjs
@@ -148,6 +148,8 @@ class JitsiHandler {
       // Check if the track should be muted, unless it is screen sharing.
       if ((this.isWebcam || track.getType() !== 'video') && this.isMuted[track.getType()]) {
         track.mute();
+      } else {
+        track.unmute();
       }
 
       // Add mute overlay
@@ -163,9 +165,9 @@ class JitsiHandler {
       }
 
       if (track.getType() in this.localTracks) {
-        this.room.replaceTrack(this.localTracks[track.getType()], track);
+        await this.room.replaceTrack(this.localTracks[track.getType()], track);
       } else {
-        this.room.addTrack(track);
+        await this.room.addTrack(track);
       }
 
       this.localTracks[track.getType()] = track;
@@ -323,7 +325,8 @@ class JitsiHandler {
       {
         e2eping: {
           pingInterval: -1
-        }
+        },
+        enableLayerSuspension: true
       }
     );
     this.room.on(JitsiMeetJS.events.conference.TRACK_ADDED, this.onRemoteTrack.bind(this));
@@ -352,12 +355,8 @@ class JitsiHandler {
 
     this.room.on(JitsiMeetJS.events.conference.PARTICIPANT_PROPERTY_CHANGED, this.setRemoteVolumeMeter.bind(this));
 
-    // This is required yet not documented :(
-    // https://github.com/jitsi/lib-jitsi-meet/issues/1333
-    this.room.setReceiverVideoConstraint(720);
-    this.room.setSenderVideoConstraint(720);
-
     this.room.setDisplayName(this.userName);
+    this.room.setSenderVideoConstraint(720);
     this.room.join(this.password);
   }
 

--- a/extensions/jitsi/common/jitsi.mjs
+++ b/extensions/jitsi/common/jitsi.mjs
@@ -597,7 +597,7 @@ class JitsiHandler {
    * Update the playerIdToParticipantIdMapping, and check if there is any dangling user
    * @param playerIdToParticipantIdMapping
    */
-  updateMappingAndRemoveDanglingUser(playerIdToParticipantIdMapping) {
+  updateIdMappingAndRemoveDanglingUser(playerIdToParticipantIdMapping) {
     this.playerIdToParticipantIdMapping = playerIdToParticipantIdMapping;
     $('#jitsi-remote-container > .jitsi-user-container').each(function() {
       if (Object.values(playerIdToParticipantIdMapping).includes($(this).attr('data-id'))) {

--- a/extensions/jitsi/standalone.mjs
+++ b/extensions/jitsi/standalone.mjs
@@ -59,7 +59,7 @@ class Standalone {
         if (Object.keys(this.meetingName2playerId2ParticipantIdMapping[meetingName]).includes(msg.playerID)) {
           delete this.meetingName2playerId2ParticipantIdMapping[meetingName][msg.playerID];
           for (const playerID in this.meetingName2playerId2ParticipantIdMapping[meetingName]) {
-            this.helper.callS2cAPI(playerID, 'jitsi', 'updateIdMapping', 5000, this.meetingName2playerId2ParticipantIdMapping[meetingName]);
+            this.helper.callS2cAPI(playerID, 'jitsi', 'updateIdMappingAndRemoveDanglingUser', 5000, this.meetingName2playerId2ParticipantIdMapping[meetingName]);
           }
         }
       }
@@ -106,7 +106,6 @@ class Standalone {
    * Update the mapping for the player ID and the Jitsi participant ID.
    * @param {Player} player - player information
    * @param {object} args - participant id and  meeting name
-   * @returns string
    */
    async c2s_updateIdMapping(player, args) {
     const {participantId, meetingName} = args;
@@ -121,7 +120,7 @@ class Standalone {
     }
 
     for (const playerID in this.meetingName2playerId2ParticipantIdMapping[meetingName]) {
-      this.helper.callS2cAPI(playerID, 'jitsi', 'updateIdMapping', 5000, this.meetingName2playerId2ParticipantIdMapping[meetingName]);
+      this.helper.callS2cAPI(playerID, 'jitsi', 'updateIdMappingAndRemoveDanglingUser', 5000, this.meetingName2playerId2ParticipantIdMapping[meetingName]);
     }
 
     return true;

--- a/extensions/jitsi/standalone.mjs
+++ b/extensions/jitsi/standalone.mjs
@@ -49,6 +49,21 @@ class Standalone {
    * Initializes the extension.
    */
   async initialize() {
+    // Notify to remove the recently quit user.
+    this.helper.registerOnPlayerUpdate((msg) => {
+      if (!msg?.removed) {
+        return;
+      }
+
+      for (const meetingName in this.meetingName2playerId2ParticipantIdMapping) {
+        if (Object.keys(this.meetingName2playerId2ParticipantIdMapping[meetingName]).includes(msg.playerID)) {
+          delete this.meetingName2playerId2ParticipantIdMapping[meetingName][msg.playerID];
+          for (const playerID in this.meetingName2playerId2ParticipantIdMapping[meetingName]) {
+            this.helper.callS2cAPI(playerID, 'jitsi', 'updateIdMapping', 5000, this.meetingName2playerId2ParticipantIdMapping[meetingName]);
+          }
+        }
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
1. Maintain a mapping for the Jitsi participant ID and the player ID, in order to hide dangling participants in the Jitsi conference (if a participant ID does not map to any player, hide that participant)
2. Reuse the Jitsi object between connections. This might solve the issue that repeatedly enter and quit Jitsi slow down the browser. 
3. Add a lock to the `unload` function, so that we won't quit a Jitsi conference multiple times.
4. Select the fullscreen participant to get better video streaming quality.