### PR TITLE
Enable hiding display name in MapRenderer

### DIFF
--- a/extensions/setting/common/client.mjs
+++ b/extensions/setting/common/client.mjs
@@ -299,6 +299,14 @@ class Client {
       this.helper.gameClient.movementManager.sendPlayerUpdateInternal(msg);
     }, 0);
 
+    this.tab.addSubsection('general', 'canvas_display', '地圖顯示設定', 0);
+    this.tab.addSwitch('canvas_display', 'player_name_display', '隱藏使用者名稱', false, (value) => {
+      this.helper.mapRenderer.setHidePlayerName(value);
+    }, 0);
+    this.tab.addSwitch('canvas_display', 'NPC_name_display', '隱藏ＮＰＣ名稱', false, (value) => {
+      this.helper.mapRenderer.setHideNPCName(value);
+    }, 0);
+
     this.tab.addSwitch('general', 'data_collect', '去識別化資料蒐集', true, (value) => {
       console.log('general data', value);
     }, 50);

--- a/sites/game-client/map-renderer.mjs
+++ b/sites/game-client/map-renderer.mjs
@@ -83,6 +83,9 @@ class MapRenderer {
     this.viewerPosition = new MapCoord('', NaN, NaN);
     this.viewportFollow = null; // will be initialized in this.initializeViewerPosition()
 
+    this._hidePlayerName = false;
+    this._hideNPCName = false;
+
     window.addEventListener('dataReady', this.initializeViewerPosition.bind(this));
 
     /**
@@ -121,6 +124,22 @@ class MapRenderer {
    */
   setGameClient(gameClient) {
     this.gameClient = gameClient;
+  }
+
+  /**
+   * Set the value of `this._hidePlayerName`.
+   * @param {Boolean} value
+   */
+  setHidePlayerName(value) {
+    this._hidePlayerName = value;
+  }
+
+  /**
+   * Set the value of `this._hideNPCName`.
+   * @param {Boolean} value
+   */
+  setHideNPCName(value) {
+    this._hideNPCName = value;
   }
 
   /**
@@ -641,6 +660,11 @@ class MapRenderer {
    */
   _drawOneCharacterName(player) {
     const {mapCoord, displayName, NPCHighlight} = player.getDrawInfo();
+
+    // No need to draw if it is set to be hidden.
+    if ((!NPCHighlight && this._hidePlayerName) || (NPCHighlight && this._hideNPCName)) {
+      return;
+    }
 
     // If we're not on the same map, we don't need to draw it.
     if (mapCoord.mapName !== this.viewerPosition.mapName) return;


### PR DESCRIPTION
The `addSwitch()` function in settings extension should be fixed so that this commit can work correctly.