### PR TITLE
Some fixes in the cat adventure extension.

### DIFF
--- a/extensions/escape-game/standalone.mjs
+++ b/extensions/escape-game/standalone.mjs
@@ -179,7 +179,7 @@ class Standalone {
    * Quit the team
    * @param {string} playerID The player id.
    */
-   async quitTeam(playerID) {
+  async quitTeam(playerID) {
     // Check if the team exists.
     if (!this.playerToTeam.has(playerID)) {
       throw new Error(`Player ${playerID} trys to quit a non-exist team.`);
@@ -666,7 +666,7 @@ class Standalone {
   /**
    * Give a redeem code to the user.
    */
-   async s2s_sf_giveRedeemCode(srcExt, playerID, kwargs, sfInfo) {
+  async s2s_sf_giveRedeemCode(srcExt, playerID, kwargs, sfInfo) {
     const {nextState, errorState} = kwargs;
     let {redeemCodes, eventName} = kwargs;
 
@@ -771,7 +771,7 @@ class Team {
    * @param {string} playerID The player ID.
    */
   removePlayer(playerID) {
-    if (!this.playerIDs.includes(playerID) || this.isFinalized) {
+    if (!this.playerIDs.includes(playerID)) {
       return false;
     }
     this.givenItems.delete(playerID);

--- a/extensions/escape-game/standalone.mjs
+++ b/extensions/escape-game/standalone.mjs
@@ -16,7 +16,6 @@ import {promisify} from 'util';
 import {fileURLToPath} from 'url';
 import InteractiveObjectServerBaseClass from '../../common/interactive-object/server.mjs';
 import {getRunPath, getConfigPath} from '../../common/path-util/path.mjs';
-import DataStore from '../../common/rpc-directory/data-store.mjs';
 
 const MAX_PLAYER_PER_TEAM = 5;
 
@@ -502,7 +501,7 @@ class Standalone {
 
       const playerList = `
         <ul>
-          ${this.playerToTeam.get(playerID).playerIDs.map(pid => `<li>${pid}</li>`).join('')}
+          ${this.playerToTeam.get(playerID).playerIDs.map(pid => `<li>${this.helper.gameState.getPlayer(pid).displayName}</li>`).join('')}
         </ul>
       `;
       await this.helper.callS2cAPI(playerID, 'dialog', 'showDialog', 60*1000,
@@ -552,8 +551,7 @@ class Standalone {
 
       this.finalizeTeam(playerID, this.playerToTeam.get(playerID).teamId);
 
-      await this.helper.callS2cAPI(playerID, 'dialog', 'showDialog', 60*1000,
-        sfInfo.name, 'Finalized');
+      // await this.helper.callS2cAPI(playerID, 'dialog', 'showDialog', 60*1000, sfInfo.name, 'Finalized');
 
       return nextState;
     } catch (e) {
@@ -676,9 +674,10 @@ class Standalone {
 
     let redeemCode = null;
 
+    const redeemedCodes = new Set(Object.values(this.distributedCodes[eventName]));
     if (!(playerID in this.distributedCodes[eventName])) {
       for (let i = 0; i < redeemCodes.length; i++) {
-        if (!Object.values(this.distributedCodes[eventName]).includes(redeemCodes[i])) {
+        if (!redeemedCodes.has(redeemCodes[i])) {
           redeemCode = redeemCodes[i];
           break;
         }


### PR DESCRIPTION
1. Use Set instead of Array to speed up the query to redeemed codes.
2. Remove the finalized check in the quit team function.
3. List of team members now shows the player displayName instead of the playerID.
4. The finalized dialog should be called in the team-manager config, not hardcode in the extension.