### PR TITLE
Fix some issues regarding the displayName.

### DIFF
--- a/sites/game-client/game-client.mjs
+++ b/sites/game-client/game-client.mjs
@@ -145,6 +145,7 @@ class GameClient {
     game.mapRendererOverlay.show(OverlayPosition.MAIN_VIEW);
     this.avatarSelectionPage.hide();
     this.inputManager.focusedElement = this.mapRenderer.getInputEventDOM();
+    this.inputManager.hasStarted = true;
     this.mainUI.introModal.show();
 
     // Start the browser side of all extensions.

--- a/sites/game-client/input-manager.mjs
+++ b/sites/game-client/input-manager.mjs
@@ -23,6 +23,7 @@ class InputManager {
     this.keydownEveryTickCallbacks = []; // each element is a {DOMElement, callback} object
     this.keydownOnceCallbacks = []; // each element is a {DOMElement, callback} object
     this.keyupCallbacks = []; // each element is a {DOMElement, callback} object
+    this.hasStarted = false; // if the game has started
 
     // TODO: Better way of maintaining focused element.
     this.focusedElement = document.activeElement;
@@ -33,6 +34,10 @@ class InputManager {
       // We trigger `keydownOnceCallbacks` instead of `keydownEveryTickCallbacks`.
       // Since the browser will continuously fire keydown event if key remains pressed, we have to check if this is the first event.
       if (this.pressedKeys.has(event.key)) {
+        return;
+      }
+      // If the game has not started, the keydown event should not be sent to the game.
+      if (!this.hasStarted) {
         return;
       }
       this.pressedKeys.set(event.key, {code: event.code});

--- a/sites/game-client/user-info.css
+++ b/sites/game-client/user-info.css
@@ -26,6 +26,9 @@
   font: normal normal bold 34px/40px Noto Sans CJK TC;
   letter-spacing: 0px;
   color: #151515;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .user-points {


### PR DESCRIPTION
1. In the input manager, ignore keydown event until the game starts. This prevents the input manager catch the event when the user is inputting the displayName.
2. Truncate the player's displayName in the card
![image](https://user-images.githubusercontent.com/4427280/143444296-d1785930-f236-4391-8431-2300ce4d5990.png)
