### PR TITLE
Fix a lot of problems in movement-manager

### DIFF
--- a/common/gamelib/move-check.mjs
+++ b/common/gamelib/move-check.mjs
@@ -4,6 +4,9 @@
 const PLAYER_MOVE_TIME_INTERVAL = 100; // ms
 const PLAYER_MOVE_DISTANCE_LIMIT = 1; // cell
 
+// const movementLogger = console;
+const movementLogger = {debug: () => {}};
+
 /**
  * TODO
  * @param {Player} oldPlayerData - TODO
@@ -13,11 +16,15 @@ const PLAYER_MOVE_DISTANCE_LIMIT = 1; // cell
  * @return {Boolean}
  */
 function checkPlayerMove(oldPlayerData, updateMessage, gameMap, clientSide=false) {
-  let canMove = true;
-  canMove = canMove && _speedCheck(oldPlayerData, updateMessage, clientSide);
-  if (!canMove) console.debug('- speed check failed');
-  canMove = canMove && _borderAndWallCheck(oldPlayerData, updateMessage, gameMap);
-  return canMove;
+  if (!_speedCheck(oldPlayerData, updateMessage, clientSide)) {
+    movementLogger.debug('- speed check failed');
+    return false;
+  }
+  if (!_borderAndWallCheck(oldPlayerData, updateMessage, gameMap)) {
+    movementLogger.debug('- border and wall check failed');
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -120,6 +127,7 @@ function checkOccupationOnClient(coord, gameState) {
 }
 
 export {
+  movementLogger,
   checkPlayerMove,
   checkPlayerMoveOnlyBorderAndWall,
   checkPlayerMoveOnlySpeed,

--- a/common/gamelib/move-check.mjs
+++ b/common/gamelib/move-check.mjs
@@ -15,6 +15,7 @@ const PLAYER_MOVE_DISTANCE_LIMIT = 1; // cell
 function checkPlayerMove(oldPlayerData, updateMessage, gameMap, clientSide=false) {
   let canMove = true;
   canMove = canMove && _speedCheck(oldPlayerData, updateMessage, clientSide);
+  if (!canMove) console.debug('- speed check failed');
   canMove = canMove && _borderAndWallCheck(oldPlayerData, updateMessage, gameMap);
   return canMove;
 }

--- a/services/gateway/gateway-service.mjs
+++ b/services/gateway/gateway-service.mjs
@@ -500,7 +500,7 @@ class GatewayService {
   async _teleportPlayerInternal(socket, msg, allowOverlap=false) {
     const res = await socket.moveLock.acquire('move', async () => {
       // If the player doesn't move at all, just return true.
-      if (socket.playerData.mapCoord.equalsTo(msg.mapCoord)) {
+      if (socket.playerData.mapCoord.equalsTo(msg.mapCoord) && socket.playerData.ghostMode === msg.ghostMode) {
         return true;
       }
 

--- a/services/gateway/gateway-service.mjs
+++ b/services/gateway/gateway-service.mjs
@@ -479,7 +479,7 @@ class GatewayService {
 
     // if the player moves
     if (updateMsg.mapCoord !== undefined) {
-      this.movementManager.handlePlayerMove(this, socket, updateMsg, failOnPlayerUpdate.bind(this));
+      this.movementManager.recvPlayerMoveMessage(this, socket, updateMsg, failOnPlayerUpdate.bind(this));
       return;
     } else {
       // If the player didn't move, still update everyone.
@@ -499,6 +499,11 @@ class GatewayService {
    */
   async _teleportPlayerInternal(socket, msg, allowOverlap=false) {
     const res = await socket.moveLock.acquire('move', async () => {
+      // If the player doesn't move at all, just return true.
+      if (socket.playerData.mapCoord.equalsTo(msg.mapCoord)) {
+        return true;
+      }
+
       const ret = await this._enterCoord(msg.mapCoord);
 
       // If the player was in ghost mode, ignore the occupation check.


### PR DESCRIPTION
From telegram (I'm too lazy):

```
1. 假設有兩個 player update message 被同時送來，理論上應該要 clear timeout，也就是同時只會有一個 pending message，但看起來 clear timeout 沒有在運作
2. _teleportPlayerInternal 如果起始跟結束座標不相同就會失敗（也就是沒有移動的話）
3. 因為 handlePlayerMove 有用到 async await，所以可能會有 context switch 造成的 race condition
```

In short, the original logic of processing playerUpdateMessage is using a cache of size=1 to store the pending playerUpdatemessage. However, this will lead to discarding valid messages when multiple messages flood the server. The refactored code will use an array to store all the pending messages and process them sequentially.