### PR TITLE
Terminal one man team

### DIFF
--- a/extensions/escape-game/common/client.mjs
+++ b/extensions/escape-game/common/client.mjs
@@ -5,6 +5,8 @@ import Modal from '/static/sites/game-client/ui/modal.mjs';
 import {MapCoord} from '/static/common/maplib/map.mjs';
 import InteractiveObjectClientBaseClass from '/static/common/interactive-object/client.mjs';
 
+const LAYER_DOOR = {zIndex: 6, layerName: 'escapeGameDoor'};
+
 const TERMINAL_CONTAINER = 'terminal-container';
 const TERMINAL_DIV = 'terminal';
 
@@ -74,6 +76,8 @@ class Client {
   async gameStart() {
     this.modal = new TerminalModal(this.helper.mainUI);
     this.modal.registerCallbacks(this.setupPty.bind(this), this.cleanup.bind(this));
+
+    this.helper.mapRenderer.registerCustomizedLayerToDraw(LAYER_DOOR.zIndex, LAYER_DOOR.layerName);
 
     const listOfTerminals = await this.helper.callC2sAPI('escape-game', 'getListOfTerminals', this.helper.defaultTimeout);
     for (const terminalId of listOfTerminals) {

--- a/run/map/assets.json
+++ b/run/map/assets.json
@@ -8768,6 +8768,18 @@
         14
       ]
     },
+    "escapeGameDoor": {
+      "B": [
+        "base",
+        10,
+        4
+      ],
+      "O": [
+        "base",
+        8,
+        19
+      ]
+    },
     "bombmanBombExplode": {
       "BE": [
         "base",

--- a/run/terminal/example-terminal1.json
+++ b/run/terminal/example-terminal1.json
@@ -23,28 +23,18 @@
     "initialState": "baseState",
     "states": {
       "baseState": {
-        "func": "checkIsInFinalizedTeam",
+        "func": "forceFinalizeTeam",
         "kwargs": {
-          "nextState": "s1",
-          "errorState": "s2"
+          "nextState": "s1"
         }
       },
       "s1": {
         "func": "showTerminal",
         "kwargs": {
-          "nextState": "s3"
+          "nextState": "s2"
         }
       },
       "s2": {
-        "func": "showDialog",
-        "kwargs": {
-          "dialogs": "You are not in a finalized team, maybe join the team first?",
-          "options": {
-            "Bye": "s3"
-          }
-        }
-      },
-      "s3": {
         "func": "exit",
         "kwargs": {
           "next": "baseState"

--- a/run/terminal/example-terminal2.json
+++ b/run/terminal/example-terminal2.json
@@ -23,28 +23,18 @@
     "initialState": "baseState",
     "states": {
       "baseState": {
-        "func": "checkIsInFinalizedTeam",
+        "func": "forceFinalizeTeam",
         "kwargs": {
-          "nextState": "s1",
-          "errorState": "s2"
+          "nextState": "s1"
         }
       },
       "s1": {
         "func": "showTerminal",
         "kwargs": {
-          "nextState": "s3"
+          "nextState": "s2"
         }
       },
       "s2": {
-        "func": "showDialog",
-        "kwargs": {
-          "dialogs": "You are not in a finalized team, maybe join the team first?",
-          "options": {
-            "Bye": "s3"
-          }
-        }
-      },
-      "s3": {
         "func": "exit",
         "kwargs": {
           "next": "baseState"

--- a/tiled-maps/scripts/generateMapConfig.mjs
+++ b/tiled-maps/scripts/generateMapConfig.mjs
@@ -484,6 +484,18 @@ newAssetsConfig.layerMap.bombmanBombExplode = {
         11
       ]
     };
+newAssetsConfig.layerMap.escapeGameDoor = {
+      "B": [
+        "base",
+        10,
+        4
+      ],
+      "O": [
+        "base",
+        8,
+        19
+      ]
+    };
 
 writeFileToJSON(assetsConfigPath, newAssetsConfig);
 


### PR DESCRIPTION
Added a function to check if the player is in the team. If not, it creates a one-man team for the player and finalize it.
Since all terminal NPCs now use this function as the base state, everyone is able to access the terminal without having to create a team.