### PR TITLE
force a team to finalize when the player interacts with a terminal NPC

### DIFF
--- a/extensions/escape-game/standalone.mjs
+++ b/extensions/escape-game/standalone.mjs
@@ -111,6 +111,7 @@ class Standalone {
     this.terminalObjects.forEach((v) => {
       v.registerExtStateFunc('showTerminal', 'escape-game', 'sf_showTerminal');
       v.registerExtStateFunc('checkIsInFinalizedTeam', 'escape-game', 'sf_checkIsInFinalizedTeam');
+      v.registerExtStateFunc('forceFinalizeTeam', 'escape-game', 'sf_forceFinalizeTeam');
     });
   }
 
@@ -384,6 +385,31 @@ class Standalone {
    */
   async c2s_getListOfTerminals(player) {
     return Array.from(this.terminalObjects.keys());
+  }
+
+  /**
+   * Make sure the player is in a finalized team. If not, create
+   * a team and finalize it immediately.
+   * This function will not notify any other teammates as it assumes all
+   * teams to have only one member.
+   */
+
+  async s2s_sf_forceFinalizeTeam(srcExt, playerID, kwargs, sfInfo) {
+    const {nextState} = kwargs;
+
+    if (!this.playerToTeam.has(playerID)) {
+      // Create a team.
+      const teamID = await this.createTeam(playerID);
+      await this.joinTeam(playerID, teamID);
+    }
+
+    if (!this.playerToTeam.get(playerID).isFinalized) {
+      // Finalize the team.
+      this.playerToTeam.get(playerID).isFinalized = true;
+      await this.saveData();
+    }
+
+    return nextState;
   }
 
   /**

--- a/run/terminal/example-terminal1.json
+++ b/run/terminal/example-terminal1.json
@@ -23,28 +23,18 @@
     "initialState": "baseState",
     "states": {
       "baseState": {
-        "func": "checkIsInFinalizedTeam",
+        "func": "forceFinalizeTeam",
         "kwargs": {
-          "nextState": "s1",
-          "errorState": "s2"
+          "nextState": "s1"
         }
       },
       "s1": {
         "func": "showTerminal",
         "kwargs": {
-          "nextState": "s3"
+          "nextState": "s2"
         }
       },
       "s2": {
-        "func": "showDialog",
-        "kwargs": {
-          "dialogs": "You are not in a finalized team, maybe join the team first?",
-          "options": {
-            "Bye": "s3"
-          }
-        }
-      },
-      "s3": {
         "func": "exit",
         "kwargs": {
           "next": "baseState"

--- a/run/terminal/example-terminal2.json
+++ b/run/terminal/example-terminal2.json
@@ -23,28 +23,18 @@
     "initialState": "baseState",
     "states": {
       "baseState": {
-        "func": "checkIsInFinalizedTeam",
+        "func": "forceFinalizeTeam",
         "kwargs": {
-          "nextState": "s1",
-          "errorState": "s2"
+          "nextState": "s1"
         }
       },
       "s1": {
         "func": "showTerminal",
         "kwargs": {
-          "nextState": "s3"
+          "nextState": "s2"
         }
       },
       "s2": {
-        "func": "showDialog",
-        "kwargs": {
-          "dialogs": "You are not in a finalized team, maybe join the team first?",
-          "options": {
-            "Bye": "s3"
-          }
-        }
-      },
-      "s3": {
         "func": "exit",
         "kwargs": {
           "next": "baseState"


### PR DESCRIPTION
Added a function to create a team and finalize it when a teamless player interacts with a terminal NPC. Since all terminal NPCs uses this function as the base state, the player doesn't have to go through the team creation process to interact with the terminal.