### PR TITLE
Terminal server on demand, done on the server side

### DIFF
--- a/common/interactive-object/server.mjs
+++ b/common/interactive-object/server.mjs
@@ -66,6 +66,7 @@ function displayValidation(display) {
  * TODO: jsdoc
  */
 class InteractiveObjectServerBaseClass {
+  static IOBJ_PREFIX = "iobj-"
   /**
    * Create the standalone extension service object but does not start it.
    * @constructor
@@ -112,7 +113,7 @@ class InteractiveObjectServerBaseClass {
 
     // Create the executor
     const sfInfo = {
-      name: `iobj-${this.objectName}`,
+      name: `${InteractiveObjectServerBaseClass.IOBJ_PREFIX}${this.objectName}`,
       visibleName: `${this.visibleName}`
     };
     this.fsmExecutor = new FSMExecutor(this.helper, this.config.FSM, sfInfo);

--- a/extensions/escape-game/common/client.mjs
+++ b/extensions/escape-game/common/client.mjs
@@ -169,7 +169,7 @@ class Client {
       } else if (cfg.layerName === 'terminalName') {
         cfg.renderArgs = {
           mapCoord: mapCoord,
-          displayName: terminalId,
+          displayName: clientInfo.visibleName,
           getDrawInfo() {
             return {mapCoord: this.mapCoord, displayName: this.displayName};
           },

--- a/extensions/escape-game/common/client.mjs
+++ b/extensions/escape-game/common/client.mjs
@@ -105,10 +105,12 @@ class Client {
       this.term.write('\r\n*** Connected ***\r\n');
 
       this.term.onData((data) => {
+        console.log("Inputttt");
         this.socket.emit('ptyDataInput', data);
       });
 
       this.socket.on('ptyDataOutput', (data) => {
+        console.log("Outputtt");
         this.term.write(data);
       });
 

--- a/extensions/escape-game/standalone.mjs
+++ b/extensions/escape-game/standalone.mjs
@@ -73,7 +73,7 @@ class Standalone {
     fs.readdirSync(getRunPath('terminal')).filter(v => v.endsWith('.json')).forEach((file) => {
       const terminalName = file.slice(0, -('.json'.length));
       const terminal = new TerminalObject(helper, terminalName, getRunPath('terminal', file));
-      this.terminalObjects.set(`iobj-${terminal.objectName}`, terminal);
+      this.terminalObjects.set(`${InteractiveObjectServerBaseClass.IOBJ_PREFIX}${terminal.objectName}`, terminal);
     });
 
     // this.defaultTerminals determines the list of containers to start when the team is created.

--- a/terminal-server/cleanup.sh
+++ b/terminal-server/cleanup.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker stop $(docker ps -a -q --filter="name=escape_")
+docker kill $(docker ps -a -q --filter="name=escape_")

--- a/terminal-server/config/default.json
+++ b/terminal-server/config/default.json
@@ -1,4 +1,5 @@
 {
     "serverPort": 5050,
-    "secret": "secret"
+    "secret": "secret",
+    "secondChanceReaperInterval": 300000
 }

--- a/terminal-server/config/default.json
+++ b/terminal-server/config/default.json
@@ -1,5 +1,5 @@
 {
     "serverPort": 5050,
     "secret": "secret",
-    "secondChanceReaperInterval": 300000
+    "secondChanceReaperInterval": 3000
 }

--- a/terminal-server/container-handler.mjs
+++ b/terminal-server/container-handler.mjs
@@ -20,6 +20,8 @@ class ContainerHandler {
     this.containerName = containerPrefix + randomBytes(32).toString('hex');
     this.imageName = imageName;
     this.ptys = {};
+    // Set the essential property for the container reaper
+    this.hasSecondChance = true;
   }
 
   /**
@@ -48,7 +50,9 @@ class ContainerHandler {
     }
 
     // Redirect the input to pty.
+    // And prevent it from being cleaned by the reaper
     socket.on('ptyDataInput', (data) => {
+      this.hasSecondChance = true;
       this.ptys[socket.id].write(data);
     });
 

--- a/terminal-server/container-handler.mjs
+++ b/terminal-server/container-handler.mjs
@@ -8,7 +8,7 @@ const pty = require('node-pty');
 const promisify = require('util').promisify;
 const randomBytes = require('crypto').randomBytes;
 const exec = promisify(require('child_process').exec);
-
+const AsyncLock = require('async-lock');
 const containerPrefix = 'escape_';
 
 /**
@@ -21,7 +21,12 @@ class ContainerHandler {
     this.imageName = imageName;
     this.ptys = {};
     // Set the essential property for the container reaper
-    this.hasSecondChance = true;
+    
+    this.hasSecondChance = false;
+    // true: the conatiner is using; false: the container is idle
+    this.handlerStatus = 0;
+    // -1: the handler is no need; 0: the handler has no container; 1: the handler has a container
+    this.statusLock = new AsyncLock();
   }
 
   /**

--- a/terminal-server/container-handler.mjs
+++ b/terminal-server/container-handler.mjs
@@ -76,10 +76,10 @@ class ContainerHandler {
    */
   async destroyContainer() {
     try {
-      let ret = await exec(`docker stop ${this.containerName}`);
+      let ret = await exec(`docker kill ${this.containerName}`);
       return !!ret.stderr;
     } catch (err) {
-      console.error(`Failed to stop ${this.containerName}: `, err);
+      console.error(`Failed to kill ${this.containerName}: `, err);
     }
   }
 }

--- a/terminal-server/main.mjs
+++ b/terminal-server/main.mjs
@@ -205,7 +205,7 @@ class TerminalServer {
           this._destroyContainer(containerId);
         }
       }
-    }, 3000, this);
+    }, config.get('secondChanceReaperInterval'), this);
   }
 }
 

--- a/terminal-server/main.mjs
+++ b/terminal-server/main.mjs
@@ -84,11 +84,6 @@ class TerminalServer {
     socket.on('disconnect', () => {
       this.handlers[socket.containerId].destroyPty(socket);
     });
-
-    socket.on('destroyPty', () => {
-      this.handlers[socket.containerId].destroyPty(socket);
-      socket.close();
-    });
   }
 
   /**
@@ -132,7 +127,7 @@ class TerminalServer {
       }
 
       await this.handlers[containerId].destroyContainer();
-      for (const socket in this.container2sockets[containerId]) {
+      for (const socket of this.container2sockets[containerId]) {
         try {
           socket.disconnect(true);
         } catch (e) {

--- a/terminal-server/package.json
+++ b/terminal-server/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.3.7",
     "@grpc/proto-loader": "^0.6.4",
+    "async-lock": "^1.3.0",
     "config": "^3.3.6",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",

--- a/terminal-server/terminal.proto
+++ b/terminal-server/terminal.proto
@@ -5,6 +5,7 @@ package TerminalServer;
 service TerminalServer {
   rpc CreateContainer (CreateContainerRequest) returns (CreateContainerResponse);
   rpc DestroyContainer (DestroyContainerRequest) returns (DestroyContainerResponse);
+  rpc EnsureContainerAvailable (EnsureContainerAvailableRequest) returns (EnsureContainerAvailableResponse);
 }
 
 message CreateContainerRequest {
@@ -22,4 +23,14 @@ message DestroyContainerRequest {
 
 message DestroyContainerResponse {
     bool success = 1;
+}
+
+message EnsureContainerAvailableRequest {
+  string containerId = 1;
+  string imageName = 2;
+}
+
+message EnsureContainerAvailableResponse {
+  bool success = 1;
+  string containerId = 2;
 }


### PR DESCRIPTION
In contrast to [PR#368](https://github.com/canyugs/hitcon-online/pull/368), this PR cleans up the containers in the terminal server.
If the client hasn't interacted with the container for too long, the server automatically destroys the container and disconnects with the client. This is done by a second-chance algorithm implemented in `terminal-server/main.mjs`.
`terminal-server/config/default.json` can be edited to change the interval.